### PR TITLE
refactor(main): modernise constants, logging, and type safety

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -168,7 +168,7 @@ void BeginSleep() {
   esp_sleep_enable_timer_wakeup(SleepTimer * 1000000LL);  // in Secs, 1000000LL converts to Secs as unit = 1uSec
   Serial.printf("Awake for : %.3f-secs\n", (millis() - StartTime) / 1000.0);
   Serial.printf("Entering %ld (secs) of sleep time\n", SleepTimer);
-  Serial.printf("Starting deep-sleep period...\n");
+  Serial.println("Starting deep-sleep period...");
   esp_deep_sleep_start();  // Sleep for e.g. 30 minutes
 }
 
@@ -189,7 +189,7 @@ uint8_t StartWiFi() {
   WiFi.setAutoReconnect(true);
   WiFi.begin(cfg.ssid, cfg.password);
   if (WiFi.waitForConnectResult() != WL_CONNECTED) {
-    Serial.printf("STA: Failed!\n");
+    Serial.println("STA: Failed!");
     WiFi.disconnect(false);
     delay(500);
     WiFi.begin(cfg.ssid, cfg.password);
@@ -198,14 +198,14 @@ uint8_t StartWiFi() {
     wifi_signal = WiFi.RSSI();  // Get Wifi Signal strength now, because the WiFi will be turned off to save power!
     Serial.printf("WiFi connected at: %s\n", WiFi.localIP().toString().c_str());
   } else
-    Serial.printf("WiFi connection *** FAILED ***\n");
+    Serial.println("WiFi connection *** FAILED ***");
   return WiFi.status();
 }
 
 void StopWiFi() {
   WiFi.disconnect();
   WiFi.mode(WIFI_OFF);
-  Serial.printf("WiFi switched Off\n");
+  Serial.println("WiFi switched Off");
 }
 
 void InitialiseSystem() {
@@ -286,7 +286,7 @@ void setup() {
         if (RxWeather == false) RxWeather = obtainWeatherData(client, "onecall");
         Attempts++;
       }
-      Serial.printf("Received all weather data...\n");
+      Serial.println("Received all weather data...");
       if (RxWeather) {
         StopWiFi();
         epd_poweron();
@@ -960,7 +960,7 @@ bool UpdateLocalTime() {
   struct tm timeinfo;
   char time_output[30], day_output[30], update_time[30];
   while (!getLocalTime(&timeinfo, 5000)) {  // Wait for 5-sec for time to synchronise
-    Serial.printf("Failed to obtain time\n");
+    Serial.println("Failed to obtain time");
     return false;
   }
   CurrentHour = timeinfo.tm_hour;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -718,7 +718,7 @@ void DisplayVisiCCoverUVISection(int x, int y) {
 }
 
 void Display_UVIndexLevel(int x, int y, float UVI) {
-  String Level = "";
+  const char* Level = "";
   if (UVI <= 2) Level = " (L)";
   if (UVI >= 3 && UVI <= 5) Level = " (M)";
   if (UVI >= 6 && UVI <= 7) Level = " (H)";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,14 +87,14 @@ uint8_t StartWiFi();
 void StopWiFi();
 void InitialiseSystem();
 void Convert_Readings_to_Imperial(int count);
-bool DecodeWeather(WiFiClient& json, String Type);
+bool DecodeWeather(WiFiClient& json, const String& Type);
 String ConvertUnixTime(int unix_time);
 bool obtainWeatherData(WiFiClient& client, const String& RequestType);
 float mm_to_inches(float value_mm);
 float hPa_to_inHg(float value_hPa);
 int JulianDate(int d, int m, int y);
 float SumOfPrecip(float DataArray[], int readings);
-String TitleCase(String text);
+String TitleCase(const String& text);
 void DisplayWeather();
 void DisplayGeneralInfoSection();
 void DisplayWeatherIcon(int x, int y);
@@ -111,10 +111,10 @@ void DrawMoon(int x, int y, int diameter, int dd, int mm, int yy, bool southernH
 String MoonPhase(int d, int m, int y);
 void DisplayForecastSection(int x, int y);
 void DisplayGraphSection(int x, int y);
-void DisplayConditionsSection(int x, int y, String IconName, bool IconSize);
+void DisplayConditionsSection(int x, int y, const String& IconName, bool IconSize);
 void arrow(int x, int y, int asize, float aangle, int pwidth, int plength);
 void DrawSegment(int x, int y, int o1, int o2, int o3, int o4, int o11, int o12, int o13, int o14);
-void DrawPressureAndTrend(int x, int y, float pressure, String slope);
+void DrawPressureAndTrend(int x, int y, float pressure, const String& slope);
 void DisplayStatusSection(int x, int y, int rssi);
 void DrawRSSI(int x, int y, int rssi);
 bool UpdateLocalTime();
@@ -126,19 +126,19 @@ void addtstorm(int x, int y, int scale);
 void addsun(int x, int y, int scale, bool IconSize);
 void addfog(int x, int y, int scale, int linesize, bool IconSize);
 void DrawAngledLine(int x, int y, int x1, int y1, int size, int color);
-void ClearSky(int x, int y, bool IconSize, String IconName);
-void BrokenClouds(int x, int y, bool IconSize, String IconName);
-void FewClouds(int x, int y, bool IconSize, String IconName);
-void ScatteredClouds(int x, int y, bool IconSize, String IconName);
-void Rain(int x, int y, bool IconSize, String IconName);
-void ChanceRain(int x, int y, bool IconSize, String IconName);
-void Thunderstorms(int x, int y, bool IconSize, String IconName);
-void Snow(int x, int y, bool IconSize, String IconName);
-void Mist(int x, int y, bool IconSize, String IconName);
+void ClearSky(int x, int y, bool IconSize, const String& IconName);
+void BrokenClouds(int x, int y, bool IconSize, const String& IconName);
+void FewClouds(int x, int y, bool IconSize, const String& IconName);
+void ScatteredClouds(int x, int y, bool IconSize, const String& IconName);
+void Rain(int x, int y, bool IconSize, const String& IconName);
+void ChanceRain(int x, int y, bool IconSize, const String& IconName);
+void Thunderstorms(int x, int y, bool IconSize, const String& IconName);
+void Snow(int x, int y, bool IconSize, const String& IconName);
+void Mist(int x, int y, bool IconSize, const String& IconName);
 void CloudCover(int x, int y, int CloudCover);
-void Visibility(int x, int y, String Visibility);
+void Visibility(int x, int y, const String& Visibility);
 void addmoon(int x, int y, bool IconSize);
-void Nodata(int x, int y, bool IconSize, String IconName);
+void Nodata(int x, int y, bool IconSize, const String& IconName);
 void DrawMoonImage(int x, int y);
 void DrawSunriseImage(int x, int y);
 void DrawSunsetImage(int x, int y);
@@ -402,7 +402,7 @@ void Convert_Readings_to_Imperial(int count) {
 }
 
 #ifndef SIMULATOR_BUILD
-bool DecodeWeather(WiFiClient& json, String Type) {
+bool DecodeWeather(WiFiClient& json, const String& Type) {
   Serial.printf("\nCreating object...");
   JsonDocument doc;                                         // allocate the JsonDocument
   DeserializationError error = deserializeJson(doc, json);  // Deserialize the JSON document
@@ -574,7 +574,7 @@ float SumOfPrecip(float DataArray[], int readings) {
   return sum;
 }
 
-String TitleCase(String text) {
+String TitleCase(const String& text) {
   if (text.length() > 0) {
     String temp_text = text.substring(0, 1);
     temp_text.toUpperCase();
@@ -872,7 +872,7 @@ void DisplayGraphSection(int x, int y) {
               autoscale_on, barchart_on);
 }
 
-void DisplayConditionsSection(int x, int y, String IconName, bool IconSize) {
+void DisplayConditionsSection(int x, int y, const String& IconName, bool IconSize) {
   Serial.printf("Icon name: %s\n", IconName.c_str());
   if (IconName == "01d" || IconName == "01n")
     ClearSky(x, y, IconSize, IconName);
@@ -920,7 +920,7 @@ void DrawSegment(int x, int y, int o1, int o2, int o3, int o4, int o11, int o12,
   drawLine(x + o11, y + o12, x + o13, y + o14, Black);
 }
 
-void DrawPressureAndTrend(int x, int y, float pressure, String slope) {
+void DrawPressureAndTrend(int x, int y, float pressure, const String& slope) {
   drawString(x + 25, y - 10,
              String(pressure, (strcmp(cfg.units, "M") == 0 ? 0 : 1)) + (strcmp(cfg.units, "M") == 0 ? "hPa" : "in"),
              LEFT);
@@ -1095,7 +1095,7 @@ void DrawAngledLine(int x, int y, int x1, int y1, int size, int color) {
   fillTriangle(x - dx, y + dy, x1 - dx, y1 + dy, x1 + dx, y1 - dy, color);
 }
 
-void ClearSky(int x, int y, bool IconSize, String IconName) {
+void ClearSky(int x, int y, bool IconSize, const String& IconName) {
   int scale = Small;
   if (IconName.endsWith("n")) addmoon(x, y, IconSize);
   if (IconSize == LargeIcon) scale = Large;
@@ -1103,7 +1103,7 @@ void ClearSky(int x, int y, bool IconSize, String IconName) {
   addsun(x, y, scale * (IconSize ? 1.7 : 1.2), IconSize);
 }
 
-void BrokenClouds(int x, int y, bool IconSize, String IconName) {
+void BrokenClouds(int x, int y, bool IconSize, const String& IconName) {
   int scale = Small, linesize = 5;
   if (IconName.endsWith("n")) addmoon(x, y, IconSize);
   y += 15;
@@ -1112,7 +1112,7 @@ void BrokenClouds(int x, int y, bool IconSize, String IconName) {
   addcloud(x, y, scale * (IconSize ? 1 : 0.75), linesize);
 }
 
-void FewClouds(int x, int y, bool IconSize, String IconName) {
+void FewClouds(int x, int y, bool IconSize, const String& IconName) {
   int scale = Small, linesize = 5;
   if (IconName.endsWith("n")) addmoon(x, y, IconSize);
   y += 15;
@@ -1121,7 +1121,7 @@ void FewClouds(int x, int y, bool IconSize, String IconName) {
   addsun((x + (IconSize ? 10 : 0)) - scale * 1.8, y - scale * 1.6, scale, IconSize);
 }
 
-void ScatteredClouds(int x, int y, bool IconSize, String IconName) {
+void ScatteredClouds(int x, int y, bool IconSize, const String& IconName) {
   int scale = Small, linesize = 5;
   if (IconName.endsWith("n")) addmoon(x, y, IconSize);
   y += 15;
@@ -1130,7 +1130,7 @@ void ScatteredClouds(int x, int y, bool IconSize, String IconName) {
   addcloud(x, y, scale * 0.9, linesize);                                  // Main cloud
 }
 
-void Rain(int x, int y, bool IconSize, String IconName) {
+void Rain(int x, int y, bool IconSize, const String& IconName) {
   int scale = Small, linesize = 5;
   if (IconName.endsWith("n")) addmoon(x, y, IconSize);
   y += 15;
@@ -1139,7 +1139,7 @@ void Rain(int x, int y, bool IconSize, String IconName) {
   addrain(x, y, scale, IconSize);
 }
 
-void ChanceRain(int x, int y, bool IconSize, String IconName) {
+void ChanceRain(int x, int y, bool IconSize, const String& IconName) {
   int scale = Small, linesize = 5;
   if (IconName.endsWith("n")) addmoon(x, y, IconSize);
   if (IconSize == LargeIcon) scale = Large;
@@ -1149,7 +1149,7 @@ void ChanceRain(int x, int y, bool IconSize, String IconName) {
   addrain(x, y, scale, IconSize);
 }
 
-void Thunderstorms(int x, int y, bool IconSize, String IconName) {
+void Thunderstorms(int x, int y, bool IconSize, const String& IconName) {
   int scale = Small, linesize = 5;
   if (IconName.endsWith("n")) addmoon(x, y, IconSize);
   if (IconSize == LargeIcon) scale = Large;
@@ -1158,7 +1158,7 @@ void Thunderstorms(int x, int y, bool IconSize, String IconName) {
   addtstorm(x, y, scale);
 }
 
-void Snow(int x, int y, bool IconSize, String IconName) {
+void Snow(int x, int y, bool IconSize, const String& IconName) {
   int scale = Small, linesize = 5;
   if (IconName.endsWith("n")) addmoon(x, y, IconSize);
   if (IconSize == LargeIcon) scale = Large;
@@ -1166,7 +1166,7 @@ void Snow(int x, int y, bool IconSize, String IconName) {
   addsnow(x, y, scale, IconSize);
 }
 
-void Mist(int x, int y, bool IconSize, String IconName) {
+void Mist(int x, int y, bool IconSize, const String& IconName) {
   int scale = Small, linesize = 5;
   if (IconName.endsWith("n")) addmoon(x, y, IconSize);
   if (IconSize == LargeIcon) scale = Large;
@@ -1181,7 +1181,7 @@ void CloudCover(int x, int y, int CloudCover) {
   drawString(x + 30, y, String(CloudCover) + "%", LEFT);
 }
 
-void Visibility(int x, int y, String Visibility) {
+void Visibility(int x, int y, const String& Visibility) {
   float start_angle = 0.52, end_angle = 2.61, Offset = 10;
   int r = 14;
   for (float i = start_angle; i < end_angle; i = i + 0.05) {
@@ -1209,7 +1209,7 @@ void addmoon(int x, int y, bool IconSize) {
   fillCircle(x - 16 + xOffset, y - 37 + yOffset, (int)(Small * 1.6), White);
 }
 
-void Nodata(int x, int y, bool IconSize, String IconName) {
+void Nodata(int x, int y, bool IconSize, const String& IconName) {
   if (IconSize == LargeIcon)
     setFont(OpenSans24B);
   else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -961,7 +961,7 @@ bool UpdateLocalTime() {
   struct tm timeinfo;
   char time_output[30], day_output[30], update_time[30];
   while (!getLocalTime(&timeinfo, 5000)) {  // Wait for 5-sec for time to synchronise
-    Serial.println("Failed to obtain time");
+    Serial.printf("Failed to obtain time\n");
     return false;
   }
   CurrentHour = timeinfo.tm_hour;
@@ -970,14 +970,14 @@ bool UpdateLocalTime() {
   //See http://www.cplusplus.com/reference/ctime/strftime/
   Serial.println(&timeinfo, "%a %b %d %Y   %H:%M:%S");  // Displays: Saturday, June 24 2017 14:05:49
   if (strcmp(cfg.units, "M") == 0) {
-    sprintf(day_output, "%s, %02u %s %04u", weekday_D[timeinfo.tm_wday], timeinfo.tm_mday, month_M[timeinfo.tm_mon],
-            (timeinfo.tm_year) + 1900);
+    snprintf(day_output, sizeof(day_output), "%s, %02u %s %04u", weekday_D[timeinfo.tm_wday], timeinfo.tm_mday,
+             month_M[timeinfo.tm_mon], (timeinfo.tm_year) + 1900);
     strftime(update_time, sizeof(update_time), "%H:%M:%S", &timeinfo);  // Creates: '14:05:49'
-    sprintf(time_output, "%s", update_time);
+    snprintf(time_output, sizeof(time_output), "%s", update_time);
   } else {
     strftime(day_output, sizeof(day_output), "%a %b-%d-%Y", &timeinfo);  // Creates  'Sat May-31-2019'
     strftime(update_time, sizeof(update_time), "%r", &timeinfo);         // Creates: '@ 02:05:49pm'
-    sprintf(time_output, "%s", update_time);
+    snprintf(time_output, sizeof(time_output), "%s", update_time);
   }
   Date_str = day_output;
   Time_str = time_output;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,28 +22,28 @@
 #endif
 
 enum alignment { LEFT, RIGHT, CENTER };
-#define White 0xFF
-#define LightGrey 0xBB
-#define Grey 0x88
-#define DarkGrey 0x44
-#define Black 0x00
+constexpr uint8_t White     = 0xFF;
+constexpr uint8_t LightGrey = 0xBB;
+constexpr uint8_t Grey      = 0x88;
+constexpr uint8_t DarkGrey  = 0x44;
+constexpr uint8_t Black     = 0x00;
 
-#define autoscale_on true
-#define autoscale_off false
-#define barchart_on true
-#define barchart_off false
+constexpr bool autoscale_on  = true;
+constexpr bool autoscale_off = false;
+constexpr bool barchart_on   = true;
+constexpr bool barchart_off  = false;
 
 #ifndef SIMULATOR_BUILD
 boolean LargeIcon = true;
 boolean SmallIcon = false;
-#define Large 20  // For icon drawing
-#define Small 10  // For icon drawing
+constexpr uint8_t Large = 20;  // For icon drawing
+constexpr uint8_t Small = 10;  // For icon drawing
 String Time_str = "--:--:--";
 String Date_str = "-- --- ----";
 int wifi_signal, CurrentHour = 0, CurrentMin = 0, CurrentSec = 0, vref = 1100;
 //################ PROGRAM VARIABLES and OBJECTS ##########################################
-#define max_readings 24  // Limited to 3-days here, but could go to 5-days = 40 as the data is issued
-#define max_graph_readings 16
+constexpr uint8_t max_readings       = 24;  // Limited to 3-days here, but could go to 5-days = 40 as the data is issued
+constexpr uint8_t max_graph_readings = 16;
 
 Forecast_record_type WxConditions[1];
 Forecast_record_type WxForecast[max_readings];
@@ -166,9 +166,9 @@ void BeginSleep() {
   SleepTimer = (SleepDuration * 60 - ((CurrentMin % SleepDuration) * 60 + CurrentSec)) +
                Delta;  //Some ESP32 have a RTC that is too fast to maintain accurate time, so add an offset
   esp_sleep_enable_timer_wakeup(SleepTimer * 1000000LL);  // in Secs, 1000000LL converts to Secs as unit = 1uSec
-  Serial.println("Awake for : " + String((millis() - StartTime) / 1000.0, 3) + "-secs");
-  Serial.println("Entering " + String(SleepTimer) + " (secs) of sleep time");
-  Serial.println("Starting deep-sleep period...");
+  Serial.printf("Awake for : %.3f-secs\n", (millis() - StartTime) / 1000.0);
+  Serial.printf("Entering %ld (secs) of sleep time\n", SleepTimer);
+  Serial.printf("Starting deep-sleep period...\n");
   esp_deep_sleep_start();  // Sleep for e.g. 30 minutes
 }
 
@@ -181,7 +181,7 @@ boolean SetupTime() {
 }
 
 uint8_t StartWiFi() {
-  Serial.println("\r\nConnecting to: " + String(cfg.ssid));
+  Serial.printf("\r\nConnecting to: %s\n", cfg.ssid);
   IPAddress dns(8, 8, 8, 8);  // Use Google DNS
   WiFi.disconnect();
   WiFi.mode(WIFI_STA);  // switch off AP
@@ -196,16 +196,16 @@ uint8_t StartWiFi() {
   }
   if (WiFi.status() == WL_CONNECTED) {
     wifi_signal = WiFi.RSSI();  // Get Wifi Signal strength now, because the WiFi will be turned off to save power!
-    Serial.println("WiFi connected at: " + WiFi.localIP().toString());
+    Serial.printf("WiFi connected at: %s\n", WiFi.localIP().toString().c_str());
   } else
-    Serial.println("WiFi connection *** FAILED ***");
+    Serial.printf("WiFi connection *** FAILED ***\n");
   return WiFi.status();
 }
 
 void StopWiFi() {
   WiFi.disconnect();
   WiFi.mode(WIFI_OFF);
-  Serial.println("WiFi switched Off");
+  Serial.printf("WiFi switched Off\n");
 }
 
 void InitialiseSystem() {
@@ -213,7 +213,7 @@ void InitialiseSystem() {
   Serial.begin(115200);
   while (!Serial)
     ;
-  Serial.println(String(__FILE__) + "\nStarting...");
+  Serial.printf("%s\nStarting...\n", __FILE__);
   epd_init(&epd_board_lilygo_t5_47, &ED047TC2, EPD_LUT_64K);
   epd_set_vcom(1560);
   hl = epd_hl_init(EPD_BUILTIN_WAVEFORM);
@@ -286,7 +286,7 @@ void setup() {
         if (RxWeather == false) RxWeather = obtainWeatherData(client, "onecall");
         Attempts++;
       }
-      Serial.println("Received all weather data...");
+      Serial.printf("Received all weather data...\n");
       if (RxWeather) {
         StopWiFi();
         epd_poweron();
@@ -403,89 +403,88 @@ void Convert_Readings_to_Imperial(int count) {
 
 #ifndef SIMULATOR_BUILD
 bool DecodeWeather(WiFiClient& json, String Type) {
-  Serial.print(F("\nCreating object..."));
+  Serial.printf("\nCreating object...");
   JsonDocument doc;                                         // allocate the JsonDocument
   DeserializationError error = deserializeJson(doc, json);  // Deserialize the JSON document
   if (error) {                                              // Test if parsing succeeds.
-    Serial.print(F("deserializeJson() failed: "));
-    Serial.println(error.c_str());
+    Serial.printf("deserializeJson() failed: %s\n", error.c_str());
     return false;
   }
   // convert it to a JsonObject
   JsonObject root = doc.as<JsonObject>();
-  Serial.println(" Decoding " + Type + " data");
+  Serial.printf(" Decoding %s data\n", Type.c_str());
   WxConditions[0].High = -50;  // Sentinel: replaced by daily[0] max below
   WxConditions[0].Low = 50;    // Sentinel: replaced by daily[0] min below
   JsonObject current = doc["current"];
   WxConditions[0].Sunrise = current["sunrise"];
-  Serial.println("SRis: " + String(WxConditions[0].Sunrise));
+  Serial.printf("SRis: %d\n", WxConditions[0].Sunrise);
   WxConditions[0].Sunset = current["sunset"];
-  Serial.println("SSet: " + String(WxConditions[0].Sunset));
+  Serial.printf("SSet: %d\n", WxConditions[0].Sunset);
   WxConditions[0].Temperature = current["temp"];
-  Serial.println("Temp: " + String(WxConditions[0].Temperature));
+  Serial.printf("Temp: %f\n", WxConditions[0].Temperature);
   WxConditions[0].FeelsLike = current["feels_like"];
-  Serial.println("FLik: " + String(WxConditions[0].FeelsLike));
+  Serial.printf("FLik: %f\n", WxConditions[0].FeelsLike);
   WxConditions[0].Pressure = current["pressure"];
-  Serial.println("Pres: " + String(WxConditions[0].Pressure));
+  Serial.printf("Pres: %f\n", WxConditions[0].Pressure);
   WxConditions[0].Humidity = current["humidity"];
-  Serial.println("Humi: " + String(WxConditions[0].Humidity));
+  Serial.printf("Humi: %f\n", WxConditions[0].Humidity);
   WxConditions[0].DewPoint = current["dew_point"];
-  Serial.println("DPoi: " + String(WxConditions[0].DewPoint));
+  Serial.printf("DPoi: %f\n", WxConditions[0].DewPoint);
   WxConditions[0].UVI = current["uvi"];
-  Serial.println("UVin: " + String(WxConditions[0].UVI));
+  Serial.printf("UVin: %f\n", WxConditions[0].UVI);
   WxConditions[0].Cloudcover = current["clouds"];
-  Serial.println("CCov: " + String(WxConditions[0].Cloudcover));
+  Serial.printf("CCov: %d\n", WxConditions[0].Cloudcover);
   WxConditions[0].Visibility = current["visibility"];
-  Serial.println("Visi: " + String(WxConditions[0].Visibility));
+  Serial.printf("Visi: %d\n", WxConditions[0].Visibility);
   WxConditions[0].Windspeed = current["wind_speed"];
-  Serial.println("WSpd: " + String(WxConditions[0].Windspeed));
+  Serial.printf("WSpd: %f\n", WxConditions[0].Windspeed);
   WxConditions[0].Winddir = current["wind_deg"];
-  Serial.println("WDir: " + String(WxConditions[0].Winddir));
+  Serial.printf("WDir: %d\n", WxConditions[0].Winddir);
   JsonObject current_weather = current["weather"][0];
   String Description = current_weather["description"];  // "scattered clouds"
   String Icon = current_weather["icon"];                // "01n"
   WxConditions[0].Forecast0 = Description;
-  Serial.println("Fore: " + String(WxConditions[0].Forecast0));
+  Serial.printf("Fore: %s\n", WxConditions[0].Forecast0.c_str());
   WxConditions[0].Icon = Icon;
-  Serial.println("Icon: " + String(WxConditions[0].Icon));
+  Serial.printf("Icon: %s\n", WxConditions[0].Icon.c_str());
 
   Serial.println(json);
-  Serial.print(F("\nReceiving Forecast period - "));  //------------------------------------------------
+  Serial.printf("\nReceiving Forecast period - ");  //------------------------------------------------
 
   // Daily
   JsonArray daily = root["daily"];
   WxConditions[0].Low = daily[0]["temp"]["min"].as<float>();  // Get Lowest temperature for next 24Hrs
-  Serial.println("TLow: " + String(WxConditions[0].Low));
+  Serial.printf("TLow: %f\n", WxConditions[0].Low);
   WxConditions[0].High = daily[0]["temp"]["max"].as<float>();  // Get Highest temperature for next 24Hrs
-  Serial.println("High: " + String(WxConditions[0].High));
+  Serial.printf("High: %f\n", WxConditions[0].High);
 
   //TODO: daily[1..7] has 7 more days of temp/icon/description data — add a weekly forecast row if screen space allows
 
   JsonArray list = root["hourly"];
-  byte wxIndex = 0;                                          // Index to populate WxForecast sequentially
-  Serial.println("hourly list size" + String(list.size()));  // 48 hours of hourly data is returned by the API
+  byte wxIndex = 0;                                              // Index to populate WxForecast sequentially
+  Serial.printf("hourly list size: %u\n", list.size());  // 48 hours of hourly data is returned by the API
   for (byte r = 0; r < 48 && wxIndex < 16; r += 3) {
-    Serial.println("\nPeriod-" + String(r) + "--------------");
+    Serial.printf("\nPeriod-%u--------------\n", r);
 
     WxForecast[wxIndex].Dt = list[r]["dt"].as<int>();
     WxForecast[wxIndex].Temperature = list[r]["temp"].as<float>();
-    Serial.println("Temp: " + String(WxForecast[wxIndex].Temperature));
+    Serial.printf("Temp: %f\n", WxForecast[wxIndex].Temperature);
     float t1 = (r + 1 < (int)list.size()) ? list[r + 1]["temp"].as<float>() : WxForecast[wxIndex].Temperature;
     float t2 = (r + 2 < (int)list.size()) ? list[r + 2]["temp"].as<float>() : WxForecast[wxIndex].Temperature;
     WxForecast[wxIndex].High = max(max(WxForecast[wxIndex].Temperature, t1), t2);
-    Serial.println("High: " + String(WxForecast[wxIndex].High));
+    Serial.printf("High: %f\n", WxForecast[wxIndex].High);
     WxForecast[wxIndex].Low = min(min(WxForecast[wxIndex].Temperature, t1), t2);
-    Serial.println("Low: " + String(WxForecast[wxIndex].Low));
+    Serial.printf("Low: %f\n", WxForecast[wxIndex].Low);
     WxForecast[wxIndex].Pressure = list[r]["pressure"].as<float>();
-    Serial.println("Pres: " + String(WxForecast[wxIndex].Pressure));
+    Serial.printf("Pres: %f\n", WxForecast[wxIndex].Pressure);
     WxForecast[wxIndex].Humidity = list[r]["humidity"].as<float>();
-    Serial.println("Humi: " + String(WxForecast[wxIndex].Humidity));
+    Serial.printf("Humi: %f\n", WxForecast[wxIndex].Humidity);
     WxForecast[wxIndex].Icon = list[r]["weather"][0]["icon"].as<const char*>();
-    Serial.println("Icon: " + String(WxForecast[wxIndex].Icon));
+    Serial.printf("Icon: %s\n", WxForecast[wxIndex].Icon.c_str());
     WxForecast[wxIndex].Rainfall = list[r]["rain"]["1h"].as<float>();
-    Serial.println("Rain: " + String(WxForecast[wxIndex].Rainfall));
+    Serial.printf("Rain: %f\n", WxForecast[wxIndex].Rainfall);
     WxForecast[wxIndex].Snowfall = list[r]["snow"]["1h"].as<float>();
-    Serial.println("Snow: " + String(WxForecast[wxIndex].Snowfall));
+    Serial.printf("Snow: %f\n", WxForecast[wxIndex].Snowfall);
 
     //------------------------------------------
     if (wxIndex >= 2) {
@@ -687,7 +686,7 @@ void DisplayTempHumiPressSection(int x, int y) {
 }
 
 void DisplayForecastTextSection(int x, int y) {
-#define lineWidth 34
+  constexpr uint8_t lineWidth = 34;
   setFont(OpenSans12B);
   String Wx_Description = WxConditions[0].Forecast0;
   Wx_Description.replace(".", "");  // remove any '.'
@@ -874,7 +873,7 @@ void DisplayGraphSection(int x, int y) {
 }
 
 void DisplayConditionsSection(int x, int y, String IconName, bool IconSize) {
-  Serial.println("Icon name: " + IconName);
+  Serial.printf("Icon name: %s\n", IconName.c_str());
   if (IconName == "01d" || IconName == "01n")
     ClearSky(x, y, IconSize, IconName);
   else if (IconName == "02d" || IconName == "02n")
@@ -998,7 +997,7 @@ void DrawBattery(int x, int y) {
   }
   float voltage = analogRead(36) / 4096.0 * 6.566 * (vref / 1000.0);
   if (voltage > 1) {  // Only display if there is a valid reading
-    Serial.println("\nVoltage = " + String(voltage));
+    Serial.printf("\nVoltage = %.2f\n", voltage);
     percentage = 2836.9625 * pow(voltage, 4) - 43987.4889 * pow(voltage, 3) + 255233.8134 * pow(voltage, 2) -
                  656689.7123 * voltage + 632041.7303;
     if (voltage >= 4.20) percentage = 100;
@@ -1251,8 +1250,8 @@ void DrawUVI(int x, int y) {
 */
 void DrawGraph(int x_pos, int y_pos, int gwidth, int gheight, float Y1Min, float Y1Max, String title, float DataArray[],
                int readings, boolean auto_scale, boolean barchart_mode) {
-#define auto_scale_margin 0  // Sets the autoscale increment, so axis steps up after a change of e.g. 3
-#define y_minor_axis 5       // 5 y-axis division markers
+  constexpr float   auto_scale_margin = 0;  // Sets the autoscale increment, so axis steps up after a change of e.g. 3
+  constexpr uint8_t y_minor_axis      = 5;  // 5 y-axis division markers
   setFont(OpenSans10B);
   float maxYscale = -10000;
   float minYscale = 10000;
@@ -1292,7 +1291,7 @@ void DrawGraph(int x_pos, int y_pos, int gwidth, int gheight, float Y1Min, float
     last_y = y2;
   }
   //Draw the Y-axis scale
-#define number_of_dashes 20
+  constexpr uint8_t number_of_dashes = 20;
   for (int spacing = 0; spacing <= y_minor_axis; spacing++) {
     for (int j = 0; j < number_of_dashes; j++) {  // Draw dashed graph grid lines
       if (spacing < y_minor_axis)
@@ -1312,7 +1311,7 @@ void DrawGraph(int x_pos, int y_pos, int gwidth, int gheight, float Y1Min, float
       }
     }
   }
-#define number_of_sections 2
+  constexpr uint8_t number_of_sections = 2;
   for (int i = 0; i < number_of_sections; i++) {
     drawString(20 + x_pos + gwidth / number_of_sections * i, y_pos + gheight + 10, String(i) + "d", LEFT);
     if (i < 2)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,27 +22,27 @@
 #endif
 
 enum alignment { LEFT, RIGHT, CENTER };
-constexpr uint8_t White     = 0xFF;
+constexpr uint8_t White = 0xFF;
 constexpr uint8_t LightGrey = 0xBB;
-constexpr uint8_t Grey      = 0x88;
-constexpr uint8_t DarkGrey  = 0x44;
-constexpr uint8_t Black     = 0x00;
+constexpr uint8_t Grey = 0x88;
+constexpr uint8_t DarkGrey = 0x44;
+constexpr uint8_t Black = 0x00;
 
-constexpr bool autoscale_on  = true;
+constexpr bool autoscale_on = true;
 constexpr bool autoscale_off = false;
-constexpr bool barchart_on   = true;
-constexpr bool barchart_off  = false;
+constexpr bool barchart_on = true;
+constexpr bool barchart_off = false;
 
 #ifndef SIMULATOR_BUILD
-boolean LargeIcon = true;
-boolean SmallIcon = false;
+bool LargeIcon = true;
+bool SmallIcon = false;
 constexpr uint8_t Large = 20;  // For icon drawing
 constexpr uint8_t Small = 10;  // For icon drawing
 String Time_str = "--:--:--";
 String Date_str = "-- --- ----";
 int wifi_signal, CurrentHour = 0, CurrentMin = 0, CurrentSec = 0, vref = 1100;
 //################ PROGRAM VARIABLES and OBJECTS ##########################################
-constexpr uint8_t max_readings       = 24;  // Limited to 3-days here, but could go to 5-days = 40 as the data is issued
+constexpr uint8_t max_readings = 24;  // Limited to 3-days here, but could go to 5-days = 40 as the data is issued
 constexpr uint8_t max_graph_readings = 16;
 
 Forecast_record_type WxConditions[1];
@@ -82,7 +82,7 @@ static EpdiyHighlevelState hl;
 
 #pragma region Function Prototypes
 void BeginSleep();
-boolean SetupTime();
+bool SetupTime();
 uint8_t StartWiFi();
 void StopWiFi();
 void InitialiseSystem();
@@ -117,7 +117,7 @@ void DrawSegment(int x, int y, int o1, int o2, int o3, int o4, int o11, int o12,
 void DrawPressureAndTrend(int x, int y, float pressure, String slope);
 void DisplayStatusSection(int x, int y, int rssi);
 void DrawRSSI(int x, int y, int rssi);
-boolean UpdateLocalTime();
+bool UpdateLocalTime();
 void DrawBattery(int x, int y);
 void addcloud(int x, int y, int scale, int linesize);
 void addrain(int x, int y, int scale, bool IconSize);
@@ -144,7 +144,7 @@ void DrawSunriseImage(int x, int y);
 void DrawSunsetImage(int x, int y);
 void DrawUVI(int x, int y);
 void DrawGraph(int x_pos, int y_pos, int gwidth, int gheight, float Y1Min, float Y1Max, String title, float DataArray[],
-               int readings, boolean auto_scale, boolean barchart_mode);
+               int readings, bool auto_scale, bool barchart_mode);
 void drawString(int x, int y, String text, alignment align);
 void fillCircle(int x, int y, int r, uint8_t color);
 void drawFastHLine(int16_t x0, int16_t y0, int length, uint16_t color);
@@ -172,7 +172,7 @@ void BeginSleep() {
   esp_deep_sleep_start();  // Sleep for e.g. 30 minutes
 }
 
-boolean SetupTime() {
+bool SetupTime() {
   configTime(cfg.gmtOffset_sec, cfg.daylightOffset_sec, cfg.ntpServer, "time.nist.gov");
   setenv("TZ", cfg.timezone, 1);
   tzset();  // Set the TZ environment variable
@@ -461,7 +461,7 @@ bool DecodeWeather(WiFiClient& json, String Type) {
   //TODO: daily[1..7] has 7 more days of temp/icon/description data — add a weekly forecast row if screen space allows
 
   JsonArray list = root["hourly"];
-  byte wxIndex = 0;                                              // Index to populate WxForecast sequentially
+  byte wxIndex = 0;                                      // Index to populate WxForecast sequentially
   Serial.printf("hourly list size: %u\n", list.size());  // 48 hours of hourly data is returned by the API
   for (byte r = 0; r < 48 && wxIndex < 16; r += 3) {
     Serial.printf("\nPeriod-%u--------------\n", r);
@@ -957,7 +957,7 @@ void DrawRSSI(int x, int y, int rssi) {
 }
 
 #ifndef SIMULATOR_BUILD
-boolean UpdateLocalTime() {
+bool UpdateLocalTime() {
   struct tm timeinfo;
   char time_output[30], day_output[30], update_time[30];
   while (!getLocalTime(&timeinfo, 5000)) {  // Wait for 5-sec for time to synchronise
@@ -1249,9 +1249,9 @@ void DrawUVI(int x, int y) {
     barchart_mode - true: draw filled bars; false: draw a line graph
 */
 void DrawGraph(int x_pos, int y_pos, int gwidth, int gheight, float Y1Min, float Y1Max, String title, float DataArray[],
-               int readings, boolean auto_scale, boolean barchart_mode) {
-  constexpr float   auto_scale_margin = 0;  // Sets the autoscale increment, so axis steps up after a change of e.g. 3
-  constexpr uint8_t y_minor_axis      = 5;  // 5 y-axis division markers
+               int readings, bool auto_scale, bool barchart_mode) {
+  constexpr float auto_scale_margin = 0;  // Sets the autoscale increment, so axis steps up after a change of e.g. 3
+  constexpr uint8_t y_minor_axis = 5;     // 5 y-axis division markers
   setFont(OpenSans10B);
   float maxYscale = -10000;
   float minYscale = 10000;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -509,10 +509,11 @@ bool DecodeWeather(WiFiClient& json, const String& Type) {
 //#########################################################################################
 String ConvertUnixTime(int unix_time) {
   // Returns either '21:12  ' or ' 09:12pm' depending on Units mode
+  const bool isMetric = (strcmp(cfg.units, "M") == 0);
   time_t tm = unix_time + cfg.gmtOffset_sec + cfg.daylightOffset_sec;
   struct tm* now_tm = gmtime(&tm);
   char output[40];
-  if (strcmp(cfg.units, "M") == 0) {
+  if (isMetric) {
     strftime(output, sizeof(output), "%H:%M %d/%m/%y", now_tm);
   } else {
     strftime(output, sizeof(output), "%I:%M%P %m/%d/%y", now_tm);
@@ -522,7 +523,8 @@ String ConvertUnixTime(int unix_time) {
 //#########################################################################################
 #ifndef SIMULATOR_BUILD
 bool obtainWeatherData(WiFiClient& client, const String& RequestType) {
-  const String units = (strcmp(cfg.units, "M") == 0 ? "metric" : "imperial");
+  const bool isMetric = (strcmp(cfg.units, "M") == 0);
+  const String units = (isMetric ? "metric" : "imperial");
   client.stop();  // close connection before sending a new request
   HTTPClient http;
   //api.openweathermap.org/data/3.0/onecall?lat={lat}&lon={lon}&appid={API key}
@@ -646,7 +648,8 @@ void DisplayWindSection(int x, int y, float angle, float windspeed, int Cradius)
   setFont(OpenSans24B);
   drawString(x + 3, y - 18, String(windspeed, 1), CENTER);
   setFont(OpenSans12B);
-  drawString(x, y + 25, (strcmp(cfg.units, "M") == 0 ? "m/s" : "mph"), CENTER);
+  const bool isMetric = (strcmp(cfg.units, "M") == 0);
+  drawString(x, y + 25, (isMetric ? "m/s" : "mph"), CENTER);
 }
 
 String WindDegToOrdinalDirection(float winddirection) {
@@ -687,6 +690,7 @@ void DisplayTempHumiPressSection(int x, int y) {
 
 void DisplayForecastTextSection(int x, int y) {
   constexpr uint8_t lineWidth = 34;
+  const bool isMetric = (strcmp(cfg.units, "M") == 0);
   setFont(OpenSans12B);
   String Wx_Description = WxConditions[0].Forecast0;
   Wx_Description.replace(".", "");  // remove any '.'
@@ -701,8 +705,7 @@ void DisplayForecastTextSection(int x, int y) {
     charCount++;
   }
   if (WxForecast[0].Rainfall > 0)
-    Wx_Description +=
-        " (" + String(WxForecast[0].Rainfall, 1) + String((strcmp(cfg.units, "M") == 0 ? "mm" : "in")) + ")";
+    Wx_Description += " (" + String(WxForecast[0].Rainfall, 1) + String((isMetric ? "mm" : "in")) + ")";
   int sep = Wx_Description.indexOf("~");
   String Line1 = (sep >= 0) ? Wx_Description.substring(0, sep) : Wx_Description;
   String Line2 = (sep >= 0) ? Wx_Description.substring(sep + 1) : "";
@@ -840,6 +843,7 @@ void DisplayForecastSection(int x, int y) {
 }
 
 void DisplayGraphSection(int x, int y) {
+  const bool isMetric = (strcmp(cfg.units, "M") == 0);
   int r = 0;
   do {  // Pre-load temporary arrays with data — values already in display units after DecodeWeather
     pressure_readings[r] = WxForecast[r].Pressure;
@@ -854,22 +858,18 @@ void DisplayGraphSection(int x, int y) {
   int gy = (epd_height() - gheight - 30);
   int gap = gwidth + gx;
   // (x,y,width,height,MinValue, MaxValue, Title, Data Array, AutoScale, ChartMode)
-  DrawGraph(gx + 0 * gap, gy, gwidth, gheight, 900, 1050,
-            strcmp(cfg.units, "M") == 0 ? TXT_PRESSURE_HPA : TXT_PRESSURE_IN, pressure_readings, max_graph_readings,
-            autoscale_on, barchart_off);
-  DrawGraph(gx + 1 * gap, gy, gwidth, gheight, 10, 30,
-            strcmp(cfg.units, "M") == 0 ? TXT_TEMPERATURE_C : TXT_TEMPERATURE_F, temperature_readings,
-            max_graph_readings, autoscale_on, barchart_off);
+  DrawGraph(gx + 0 * gap, gy, gwidth, gheight, 900, 1050, isMetric ? TXT_PRESSURE_HPA : TXT_PRESSURE_IN,
+            pressure_readings, max_graph_readings, autoscale_on, barchart_off);
+  DrawGraph(gx + 1 * gap, gy, gwidth, gheight, 10, 30, isMetric ? TXT_TEMPERATURE_C : TXT_TEMPERATURE_F,
+            temperature_readings, max_graph_readings, autoscale_on, barchart_off);
   DrawGraph(gx + 2 * gap, gy, gwidth, gheight, 0, 100, TXT_HUMIDITY_PERCENT, humidity_readings, max_graph_readings,
             autoscale_off, barchart_off);
   if (SumOfPrecip(rain_readings, max_graph_readings) >= SumOfPrecip(snow_readings, max_graph_readings))
-    DrawGraph(gx + 3 * gap + 5, gy, gwidth, gheight, 0, 30,
-              strcmp(cfg.units, "M") == 0 ? TXT_RAINFALL_MM : TXT_RAINFALL_IN, rain_readings, max_graph_readings,
-              autoscale_on, barchart_on);
+    DrawGraph(gx + 3 * gap + 5, gy, gwidth, gheight, 0, 30, isMetric ? TXT_RAINFALL_MM : TXT_RAINFALL_IN, rain_readings,
+              max_graph_readings, autoscale_on, barchart_on);
   else
-    DrawGraph(gx + 3 * gap + 5, gy, gwidth, gheight, 0, 30,
-              strcmp(cfg.units, "M") == 0 ? TXT_SNOWFALL_MM : TXT_SNOWFALL_IN, snow_readings, max_graph_readings,
-              autoscale_on, barchart_on);
+    DrawGraph(gx + 3 * gap + 5, gy, gwidth, gheight, 0, 30, isMetric ? TXT_SNOWFALL_MM : TXT_SNOWFALL_IN, snow_readings,
+              max_graph_readings, autoscale_on, barchart_on);
 }
 
 void DisplayConditionsSection(int x, int y, const String& IconName, bool IconSize) {
@@ -921,9 +921,8 @@ void DrawSegment(int x, int y, int o1, int o2, int o3, int o4, int o11, int o12,
 }
 
 void DrawPressureAndTrend(int x, int y, float pressure, const String& slope) {
-  drawString(x + 25, y - 10,
-             String(pressure, (strcmp(cfg.units, "M") == 0 ? 0 : 1)) + (strcmp(cfg.units, "M") == 0 ? "hPa" : "in"),
-             LEFT);
+  const bool isMetric = (strcmp(cfg.units, "M") == 0);
+  drawString(x + 25, y - 10, String(pressure, isMetric ? 0 : 1) + (isMetric ? "hPa" : "in"), LEFT);
   if (slope == "+") {
     DrawSegment(x, y, 0, 0, 8, -8, 8, -8, 16, 0);
     DrawSegment(x - 1, y, 0, 0, 8, -8, 8, -8, 16, 0);
@@ -958,6 +957,7 @@ void DrawRSSI(int x, int y, int rssi) {
 
 #ifndef SIMULATOR_BUILD
 bool UpdateLocalTime() {
+  const bool isMetric = (strcmp(cfg.units, "M") == 0);
   struct tm timeinfo;
   char time_output[30], day_output[30], update_time[30];
   while (!getLocalTime(&timeinfo, 5000)) {  // Wait for 5-sec for time to synchronise
@@ -969,7 +969,7 @@ bool UpdateLocalTime() {
   CurrentSec = timeinfo.tm_sec;
   //See http://www.cplusplus.com/reference/ctime/strftime/
   Serial.println(&timeinfo, "%a %b %d %Y   %H:%M:%S");  // Displays: Saturday, June 24 2017 14:05:49
-  if (strcmp(cfg.units, "M") == 0) {
+  if (isMetric) {
     snprintf(day_output, sizeof(day_output), "%s, %02u %s %04u", weekday_D[timeinfo.tm_wday], timeinfo.tm_mday,
              month_M[timeinfo.tm_mon], (timeinfo.tm_year) + 1900);
     strftime(update_time, sizeof(update_time), "%H:%M:%S", &timeinfo);  // Creates: '14:05:49'

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -448,7 +448,6 @@ bool DecodeWeather(WiFiClient& json, const String& Type) {
   WxConditions[0].Icon = Icon;
   Serial.printf("Icon: %s\n", WxConditions[0].Icon.c_str());
 
-  Serial.println(json);
   Serial.printf("\nReceiving Forecast period - ");  //------------------------------------------------
 
   // Daily


### PR DESCRIPTION
## Summary

A series of focused refactors to `src/main.cpp` — no behaviour changes, all building cleanly with no new warnings.

- **`#define` → `constexpr`**: All 18 numeric/bool constants replaced with typed `constexpr` variables (colour palette, icon sizes, array bounds, graph constants). Eliminates macro namespace pollution and adds type safety.
- **`Serial.println(…+String(…))` → `Serial.printf()`**: All string-concatenation logging calls replaced with `printf`-style format strings, eliminating per-call heap allocation for debug output.
- **`boolean` → `bool`**: Replaced the deprecated Arduino `boolean` typedef with standard C++ `bool` across all globals, prototypes, and definitions.
- **`sprintf` → `snprintf`**: Three unsafe `sprintf` calls in `UpdateLocalTime` now pass the buffer size.
- **`String` pass-by-value → `const String&`**: `DecodeWeather`, `TitleCase`, `DisplayConditionsSection`, all 10 weather icon functions, `DrawPressureAndTrend`, and `Visibility` — avoids a heap copy on every call.
- **`const char*` UVI label**: `Display_UVIndexLevel` now uses `const char*` instead of `String` for the five literal level labels.
- **`isMetric` local bool**: Every function that tests `strcmp(cfg.units, "M") == 0` now computes it once into `const bool isMetric` at the top, used consistently throughout.
- **Remove raw JSON dump**: `Serial.println(json)` in `DecodeWeather` printed an already-consumed stream — removed.
- **clang-format**: All changes pass `clang-format --dry-run --Werror`.

## Test plan

- [x] Firmware builds clean (`pio run`) with no errors or new warnings
- [x] Simulator WASM builds clean (`emcmake cmake` + `emmake cmake --build`) — artifacts produced in `simulator/wasm/`
- [x] All commits pass clang-format check

🤖 Generated with [Claude Code](https://claude.com/claude-code)