### PR TITLE
refactor: code quality, security hardening, and structural cleanup

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Arduino.h>
+#include <string>
 
 // GPIO for the button that triggers config mode when held at boot.
 #define CONFIG_BUTTON_PIN 39
@@ -15,17 +16,17 @@
 // #define REDACT_PASSWORD_IN_CONFIG_DOWNLOAD
 
 struct AppConfig {
-  char ssid[64];
-  char password[64];
-  char apikey[64];
-  char server[64];
-  char city[64];
-  char latitude[16];
-  char longitude[16];
-  char language[8];
-  char units[4];
-  char timezone[80];
-  char ntpServer[64];
+  std::string ssid;
+  std::string password;
+  std::string apikey;
+  std::string server;
+  std::string city;
+  std::string latitude;
+  std::string longitude;
+  std::string language;
+  std::string units;
+  std::string timezone;
+  std::string ntpServer;
   int gmtOffset_sec;
   int daylightOffset_sec;
   int sleepDuration;

--- a/include/defaults.h
+++ b/include/defaults.h
@@ -2,39 +2,39 @@
 #define DEFAULTS_H_
 
 // ---- Display layout anchor points (960x540 canvas) ----
-constexpr int kLayoutStatusX        = 600;
-constexpr int kLayoutStatusY        = 20;
-constexpr int kLayoutWindX          = 137;
-constexpr int kLayoutWindY          = 150;
-constexpr int kLayoutWindRadius     = 100;
-constexpr int kLayoutAstronomyX     = 5;
-constexpr int kLayoutAstronomyY     = 252;
-constexpr int kLayoutMainWeatherX   = 320;
-constexpr int kLayoutMainWeatherY   = 110;
-constexpr int kLayoutWeatherIconX   = 835;
-constexpr int kLayoutWeatherIconY   = 140;
-constexpr int kLayoutForecastX      = 285;
-constexpr int kLayoutForecastY      = 220;
-constexpr int kLayoutGraphX         = 320;
-constexpr int kLayoutGraphY         = 220;
+constexpr int kLayoutStatusX = 600;
+constexpr int kLayoutStatusY = 20;
+constexpr int kLayoutWindX = 137;
+constexpr int kLayoutWindY = 150;
+constexpr int kLayoutWindRadius = 100;
+constexpr int kLayoutAstronomyX = 5;
+constexpr int kLayoutAstronomyY = 252;
+constexpr int kLayoutMainWeatherX = 320;
+constexpr int kLayoutMainWeatherY = 110;
+constexpr int kLayoutWeatherIconX = 835;
+constexpr int kLayoutWeatherIconY = 140;
+constexpr int kLayoutForecastX = 285;
+constexpr int kLayoutForecastY = 220;
+constexpr int kLayoutGraphX = 320;
+constexpr int kLayoutGraphY = 220;
 
 // ---- Hardware ----
-constexpr int   kBatteryAdcPin      = 36;
-constexpr float kBatteryVoltageDiv  = 6.566f;  // voltage divider ratio for ADC pin 36
-constexpr int   kBatteryAdcBits     = 4096;    // 12-bit ADC
-constexpr int   kDefaultVref        = 1100;    // mV, overridden by eFuse calibration if available
+constexpr int kBatteryAdcPin = 36;
+constexpr float kBatteryVoltageDiv = 6.566f;  // voltage divider ratio for ADC pin 36
+constexpr int kBatteryAdcBits = 4096;         // 12-bit ADC
+constexpr int kDefaultVref = 1100;            // mV, overridden by eFuse calibration if available
 
 // ---- Default configuration values ----
 // Single source of truth used by config.cpp and any code that needs fallback values.
 
-constexpr const char* kDefaultServer      = "api.openweathermap.org";
-constexpr const char* kDefaultNtpServer   = "pool.ntp.org";
+constexpr const char* kDefaultServer = "api.openweathermap.org";
+constexpr const char* kDefaultNtpServer = "pool.ntp.org";
 constexpr const char* kDefaultNtpFallback = "time.nist.gov";
-constexpr const char* kDefaultLanguage    = "EN";
-constexpr const char* kDefaultUnits       = "M";
+constexpr const char* kDefaultLanguage = "EN";
+constexpr const char* kDefaultUnits = "M";
 
 constexpr int kDefaultSleepDuration = 60;  // minutes
-constexpr int kDefaultWakeupHour    = 8;   // 0-23
-constexpr int kDefaultSleepHour     = 23;  // 0-23
+constexpr int kDefaultWakeupHour = 8;      // 0-23
+constexpr int kDefaultSleepHour = 23;      // 0-23
 
 #endif /* ifndef DEFAULTS_H_ */

--- a/include/defaults.h
+++ b/include/defaults.h
@@ -1,8 +1,31 @@
 #ifndef DEFAULTS_H_
 #define DEFAULTS_H_
 
-// Default configuration values — single source of truth used by config.cpp
-// and any code that needs fallback values.
+// ---- Display layout anchor points (960x540 canvas) ----
+constexpr int kLayoutStatusX        = 600;
+constexpr int kLayoutStatusY        = 20;
+constexpr int kLayoutWindX          = 137;
+constexpr int kLayoutWindY          = 150;
+constexpr int kLayoutWindRadius     = 100;
+constexpr int kLayoutAstronomyX     = 5;
+constexpr int kLayoutAstronomyY     = 252;
+constexpr int kLayoutMainWeatherX   = 320;
+constexpr int kLayoutMainWeatherY   = 110;
+constexpr int kLayoutWeatherIconX   = 835;
+constexpr int kLayoutWeatherIconY   = 140;
+constexpr int kLayoutForecastX      = 285;
+constexpr int kLayoutForecastY      = 220;
+constexpr int kLayoutGraphX         = 320;
+constexpr int kLayoutGraphY         = 220;
+
+// ---- Hardware ----
+constexpr int   kBatteryAdcPin      = 36;
+constexpr float kBatteryVoltageDiv  = 6.566f;  // voltage divider ratio for ADC pin 36
+constexpr int   kBatteryAdcBits     = 4096;    // 12-bit ADC
+constexpr int   kDefaultVref        = 1100;    // mV, overridden by eFuse calibration if available
+
+// ---- Default configuration values ----
+// Single source of truth used by config.cpp and any code that needs fallback values.
 
 constexpr const char* kDefaultServer      = "api.openweathermap.org";
 constexpr const char* kDefaultNtpServer   = "pool.ntp.org";

--- a/include/defaults.h
+++ b/include/defaults.h
@@ -1,0 +1,17 @@
+#ifndef DEFAULTS_H_
+#define DEFAULTS_H_
+
+// Default configuration values — single source of truth used by config.cpp
+// and any code that needs fallback values.
+
+constexpr const char* kDefaultServer      = "api.openweathermap.org";
+constexpr const char* kDefaultNtpServer   = "pool.ntp.org";
+constexpr const char* kDefaultNtpFallback = "time.nist.gov";
+constexpr const char* kDefaultLanguage    = "EN";
+constexpr const char* kDefaultUnits       = "M";
+
+constexpr int kDefaultSleepDuration = 60;  // minutes
+constexpr int kDefaultWakeupHour    = 8;   // 0-23
+constexpr int kDefaultSleepHour     = 23;  // 0-23
+
+#endif /* ifndef DEFAULTS_H_ */

--- a/include/forecast_record.h
+++ b/include/forecast_record.h
@@ -3,9 +3,9 @@
 
 struct Forecast_record_type {  // For current Day and Day 1, 2, 3, etc
   int Dt;
-  char Icon[8];       // OWM icon code e.g. "01d", "01n" (3 chars + null)
-  char Trend;         // Pressure trend: '+', '-', '0', '='
-  char Forecast0[64]; // Weather description e.g. "scattered clouds"
+  char Icon[8];        // OWM icon code e.g. "01d", "01n" (3 chars + null)
+  char Trend;          // Pressure trend: '+', '-', '0', '='
+  char Forecast0[64];  // Weather description e.g. "scattered clouds"
   float Temperature;
   float FeelsLike;
   float DewPoint;

--- a/include/forecast_record.h
+++ b/include/forecast_record.h
@@ -1,13 +1,11 @@
 #ifndef FORECAST_RECORD_H_
 #define FORECAST_RECORD_H_
 
-#include <Arduino.h>
-
-typedef struct {  // For current Day and Day 1, 2, 3, etc
+struct Forecast_record_type {  // For current Day and Day 1, 2, 3, etc
   int Dt;
-  String Icon;
-  String Trend;
-  String Forecast0;
+  char Icon[8];       // OWM icon code e.g. "01d", "01n" (3 chars + null)
+  char Trend;         // Pressure trend: '+', '-', '0', '='
+  char Forecast0[64]; // Weather description e.g. "scattered clouds"
   float Temperature;
   float FeelsLike;
   float DewPoint;
@@ -24,6 +22,6 @@ typedef struct {  // For current Day and Day 1, 2, 3, etc
   int Sunrise;
   int Sunset;
   float UVI;
-} Forecast_record_type;
+};
 
 #endif /* ifndef FORECAST_RECORD_H_ */

--- a/simulator/main_wasm.cpp
+++ b/simulator/main_wasm.cpp
@@ -52,7 +52,7 @@ int CurrentHour = 0, CurrentMin = 0, CurrentSec = 0, vref = 1100;
 #define max_readings 24
 #define max_graph_readings 16
 
-Forecast_record_type WxConditions[1];
+Forecast_record_type WxConditions;
 Forecast_record_type WxForecast[max_readings];
 
 float pressure_readings[max_readings] = {0};
@@ -147,31 +147,31 @@ bool DecodeWeather(const std::string& json, String Type) {
   JsonObject root = doc.as<JsonObject>();
   fprintf(stderr, "Decoding %s data\n", Type.c_str());
 
-  WxConditions[0].High = -50;
-  WxConditions[0].Low = 50;
+  WxConditions.High = -50;
+  WxConditions.Low = 50;
 
   JsonObject current = doc["current"];
-  WxConditions[0].Sunrise = current["sunrise"];
-  WxConditions[0].Sunset = current["sunset"];
-  WxConditions[0].Temperature = current["temp"];
-  WxConditions[0].FeelsLike = current["feels_like"];
-  WxConditions[0].Pressure = current["pressure"];
-  WxConditions[0].Humidity = current["humidity"];
-  WxConditions[0].DewPoint = current["dew_point"];
-  WxConditions[0].UVI = current["uvi"];
-  WxConditions[0].Cloudcover = current["clouds"];
-  WxConditions[0].Visibility = current["visibility"];
-  WxConditions[0].Windspeed = current["wind_speed"];
-  WxConditions[0].Winddir = current["wind_deg"];
+  WxConditions.Sunrise = current["sunrise"];
+  WxConditions.Sunset = current["sunset"];
+  WxConditions.Temperature = current["temp"];
+  WxConditions.FeelsLike = current["feels_like"];
+  WxConditions.Pressure = current["pressure"];
+  WxConditions.Humidity = current["humidity"];
+  WxConditions.DewPoint = current["dew_point"];
+  WxConditions.UVI = current["uvi"];
+  WxConditions.Cloudcover = current["clouds"];
+  WxConditions.Visibility = current["visibility"];
+  WxConditions.Windspeed = current["wind_speed"];
+  WxConditions.Winddir = current["wind_deg"];
 
   const char* desc = current["weather"][0]["description"];
   const char* icon = current["weather"][0]["icon"];
-  WxConditions[0].Forecast0 = String(desc ? desc : "");
-  WxConditions[0].Icon = String(icon ? icon : "");
+  WxConditions.Forecast0 = String(desc ? desc : "");
+  WxConditions.Icon = String(icon ? icon : "");
 
   JsonArray daily = root["daily"];
-  WxConditions[0].Low = daily[0]["temp"]["min"].as<float>();
-  WxConditions[0].High = daily[0]["temp"]["max"].as<float>();
+  WxConditions.Low = daily[0]["temp"]["min"].as<float>();
+  WxConditions.High = daily[0]["temp"]["max"].as<float>();
 
   JsonArray list = root["hourly"];
   byte wxIndex = 0;
@@ -195,9 +195,9 @@ bool DecodeWeather(const std::string& json, String Type) {
     if (wxIndex >= 2) {
       float pt = WxForecast[0].Pressure - WxForecast[2].Pressure;
       pt = ((int)(pt * 10)) / 10.0f;
-      WxConditions[0].Trend = (pt > 0) ? "+" : (pt < 0) ? "-" : "0";
+      WxConditions.Trend = (pt > 0) ? "+" : (pt < 0) ? "-" : "0";
     } else {
-      WxConditions[0].Trend = "0";
+      WxConditions.Trend = "0";
     }
     wxIndex++;
   }

--- a/simulator/main_wasm.cpp
+++ b/simulator/main_wasm.cpp
@@ -14,6 +14,7 @@
 #include "../.pio/libdeps/display/ArduinoJson/src/ArduinoJson.h"
 
 #include "../include/config.h"
+#include "../include/defaults.h"
 #include "../include/forecast_record.h"
 #include "../include/translations/lang_en.h"
 #include "../include/fonts/opensans8b.h"

--- a/simulator/main_wasm.cpp
+++ b/simulator/main_wasm.cpp
@@ -98,7 +98,7 @@ bool loadConfig() {
 }
 void saveConfig() {}
 bool isConfigValid() {
-  return cfg.apikey[0] != '\0' && cfg.latitude[0] != '\0' && cfg.longitude[0] != '\0';
+  return !cfg.apikey.empty() && !cfg.latitude.empty() && !cfg.longitude.empty();
 }
 bool seedConfigFromHeader() {
   return false;
@@ -112,7 +112,7 @@ boolean UpdateLocalTime() {
   CurrentMin = t.tm_min;
   CurrentSec = t.tm_sec;
   char day_buf[64], time_buf[32];
-  if (strcmp(cfg.units, "M") == 0) {
+  if (cfg.units == "M") {
     snprintf(day_buf, sizeof(day_buf), "%s, %02d %s %04d", weekday_D[t.tm_wday], t.tm_mday, month_M[t.tm_mon],
              t.tm_year + 1900);
     strftime(time_buf, sizeof(time_buf), "%H:%M:%S", &t);
@@ -199,7 +199,7 @@ bool DecodeWeather(const std::string& json, String Type) {
   } else {
     WxConditions.Trend = '0';
   }
-  if (strcmp(cfg.units, "I") == 0) Convert_Readings_to_Imperial(wxIndex);
+  if (cfg.units == "I") Convert_Readings_to_Imperial(wxIndex);
   return true;
 }
 
@@ -215,10 +215,12 @@ EMSCRIPTEN_KEEPALIVE void wasm_init() {
 
 EMSCRIPTEN_KEEPALIVE void wasm_set_config(const char* city, const char* units, const char* lang, float latitude,
                                           int gmt_offset_sec, int dst_offset_sec) {
-  if (city) strncpy(cfg.city, city, sizeof(cfg.city) - 1);
-  if (units) strncpy(cfg.units, units, sizeof(cfg.units) - 1);
-  if (lang) strncpy(cfg.language, lang, sizeof(cfg.language) - 1);
-  snprintf(cfg.latitude, sizeof(cfg.latitude), "%.6f", latitude);
+  if (city) cfg.city = city;
+  if (units) cfg.units = units;
+  if (lang) cfg.language = lang;
+  char lat_buf[32];
+  snprintf(lat_buf, sizeof(lat_buf), "%.6f", latitude);
+  cfg.latitude = lat_buf;
   cfg.gmtOffset_sec = gmt_offset_sec;
   cfg.daylightOffset_sec = dst_offset_sec;
 }

--- a/simulator/main_wasm.cpp
+++ b/simulator/main_wasm.cpp
@@ -164,10 +164,8 @@ bool DecodeWeather(const std::string& json, String Type) {
   WxConditions.Windspeed = current["wind_speed"];
   WxConditions.Winddir = current["wind_deg"];
 
-  const char* desc = current["weather"][0]["description"];
-  const char* icon = current["weather"][0]["icon"];
-  WxConditions.Forecast0 = String(desc ? desc : "");
-  WxConditions.Icon = String(icon ? icon : "");
+  strlcpy(WxConditions.Forecast0, current["weather"][0]["description"] | "", sizeof(WxConditions.Forecast0));
+  strlcpy(WxConditions.Icon, current["weather"][0]["icon"] | "", sizeof(WxConditions.Icon));
 
   JsonArray daily = root["daily"];
   WxConditions.Low = daily[0]["temp"]["min"].as<float>();
@@ -187,19 +185,18 @@ bool DecodeWeather(const std::string& json, String Type) {
                                                    : (temps[1] < temps[2] ? temps[1] : temps[2]));
     WxForecast[wxIndex].Pressure = list[r]["pressure"].as<float>();
     WxForecast[wxIndex].Humidity = list[r]["humidity"].as<float>();
-    const char* ic = list[r]["weather"][0]["icon"];
-    WxForecast[wxIndex].Icon = String(ic ? ic : "");
+    strlcpy(WxForecast[wxIndex].Icon, list[r]["weather"][0]["icon"] | "", sizeof(WxForecast[wxIndex].Icon));
     WxForecast[wxIndex].Rainfall = list[r]["rain"]["1h"].as<float>();
     WxForecast[wxIndex].Snowfall = list[r]["snow"]["1h"].as<float>();
 
-    if (wxIndex >= 2) {
-      float pt = WxForecast[0].Pressure - WxForecast[2].Pressure;
-      pt = ((int)(pt * 10)) / 10.0f;
-      WxConditions.Trend = (pt > 0) ? "+" : (pt < 0) ? "-" : "0";
-    } else {
-      WxConditions.Trend = "0";
-    }
     wxIndex++;
+  }
+  if (wxIndex >= 3) {
+    float pt = WxForecast[0].Pressure - WxForecast[2].Pressure;
+    pt = ((int)(pt * 10)) / 10.0f;
+    WxConditions.Trend = (pt > 0) ? '+' : (pt < 0) ? '-' : '0';
+  } else {
+    WxConditions.Trend = '0';
   }
   if (strcmp(cfg.units, "I") == 0) Convert_Readings_to_Imperial(wxIndex);
   return true;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -45,17 +45,17 @@ bool loadConfig() {
     Serial.printf("Config parse error: %s\n", err.c_str());
     return false;
   }
-  strlcpy(cfg.ssid, doc["ssid"] | "", sizeof(cfg.ssid));
-  strlcpy(cfg.password, doc["password"] | "", sizeof(cfg.password));
-  strlcpy(cfg.apikey, doc["apikey"] | "", sizeof(cfg.apikey));
-  strlcpy(cfg.server, doc["server"] | kDefaultServer, sizeof(cfg.server));
-  strlcpy(cfg.city, doc["city"] | "", sizeof(cfg.city));
-  strlcpy(cfg.latitude, doc["latitude"] | "", sizeof(cfg.latitude));
-  strlcpy(cfg.longitude, doc["longitude"] | "", sizeof(cfg.longitude));
-  strlcpy(cfg.language, doc["language"] | kDefaultLanguage, sizeof(cfg.language));
-  strlcpy(cfg.units, doc["units"] | kDefaultUnits, sizeof(cfg.units));
-  strlcpy(cfg.timezone, doc["timezone"] | "", sizeof(cfg.timezone));
-  strlcpy(cfg.ntpServer, doc["ntpServer"] | kDefaultNtpServer, sizeof(cfg.ntpServer));
+  cfg.ssid = doc["ssid"] | "";
+  cfg.password = doc["password"] | "";
+  cfg.apikey = doc["apikey"] | "";
+  cfg.server = doc["server"] | kDefaultServer;
+  cfg.city = doc["city"] | "";
+  cfg.latitude = doc["latitude"] | "";
+  cfg.longitude = doc["longitude"] | "";
+  cfg.language = doc["language"] | kDefaultLanguage;
+  cfg.units = doc["units"] | kDefaultUnits;
+  cfg.timezone = doc["timezone"] | "";
+  cfg.ntpServer = doc["ntpServer"] | kDefaultNtpServer;
   cfg.gmtOffset_sec = doc["gmtOffset_sec"] | 0;
   cfg.daylightOffset_sec = doc["daylightOffset_sec"] | 0;
   cfg.sleepDuration = doc["sleepDuration"] | kDefaultSleepDuration;
@@ -100,23 +100,23 @@ void saveConfig() {
 }
 
 bool isConfigValid() {
-  return cfg.ssid[0] != '\0' && cfg.apikey[0] != '\0' && cfg.latitude[0] != '\0' && cfg.longitude[0] != '\0' &&
-         cfg.timezone[0] != '\0';
+  return !cfg.ssid.empty() && !cfg.apikey.empty() && !cfg.latitude.empty() && !cfg.longitude.empty() &&
+         !cfg.timezone.empty();
 }
 
 bool seedConfigFromHeader() {
 #ifdef OWM_CREDENTIALS_AVAILABLE
-  strlcpy(cfg.ssid, ssid, sizeof(cfg.ssid));
-  strlcpy(cfg.password, password, sizeof(cfg.password));
-  strlcpy(cfg.apikey, apikey.c_str(), sizeof(cfg.apikey));
-  strlcpy(cfg.server, server, sizeof(cfg.server));
-  strlcpy(cfg.city, City.c_str(), sizeof(cfg.city));
-  strlcpy(cfg.latitude, Latitude.c_str(), sizeof(cfg.latitude));
-  strlcpy(cfg.longitude, Longitude.c_str(), sizeof(cfg.longitude));
-  strlcpy(cfg.language, Language.c_str(), sizeof(cfg.language));
-  strlcpy(cfg.units, Units.c_str(), sizeof(cfg.units));
-  strlcpy(cfg.timezone, Timezone, sizeof(cfg.timezone));
-  strlcpy(cfg.ntpServer, ntpServer, sizeof(cfg.ntpServer));
+  cfg.ssid = ssid;
+  cfg.password = password;
+  cfg.apikey = apikey.c_str();
+  cfg.server = server;
+  cfg.city = City.c_str();
+  cfg.latitude = Latitude.c_str();
+  cfg.longitude = Longitude.c_str();
+  cfg.language = Language.c_str();
+  cfg.units = Units.c_str();
+  cfg.timezone = Timezone;
+  cfg.ntpServer = ntpServer;
   cfg.gmtOffset_sec = gmtOffset_sec;
   cfg.daylightOffset_sec = daylightOffset_sec;
   cfg.debugDisplayUpdate = DebugDisplayUpdate;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,4 +1,5 @@
 #include "config.h"
+#include "defaults.h"
 #include <LittleFS.h>
 #include <ArduinoJson.h>
 
@@ -47,19 +48,19 @@ bool loadConfig() {
   strlcpy(cfg.ssid, doc["ssid"] | "", sizeof(cfg.ssid));
   strlcpy(cfg.password, doc["password"] | "", sizeof(cfg.password));
   strlcpy(cfg.apikey, doc["apikey"] | "", sizeof(cfg.apikey));
-  strlcpy(cfg.server, doc["server"] | "api.openweathermap.org", sizeof(cfg.server));
+  strlcpy(cfg.server, doc["server"] | kDefaultServer, sizeof(cfg.server));
   strlcpy(cfg.city, doc["city"] | "", sizeof(cfg.city));
   strlcpy(cfg.latitude, doc["latitude"] | "", sizeof(cfg.latitude));
   strlcpy(cfg.longitude, doc["longitude"] | "", sizeof(cfg.longitude));
-  strlcpy(cfg.language, doc["language"] | "EN", sizeof(cfg.language));
-  strlcpy(cfg.units, doc["units"] | "M", sizeof(cfg.units));
+  strlcpy(cfg.language, doc["language"] | kDefaultLanguage, sizeof(cfg.language));
+  strlcpy(cfg.units, doc["units"] | kDefaultUnits, sizeof(cfg.units));
   strlcpy(cfg.timezone, doc["timezone"] | "", sizeof(cfg.timezone));
-  strlcpy(cfg.ntpServer, doc["ntpServer"] | "pool.ntp.org", sizeof(cfg.ntpServer));
+  strlcpy(cfg.ntpServer, doc["ntpServer"] | kDefaultNtpServer, sizeof(cfg.ntpServer));
   cfg.gmtOffset_sec = doc["gmtOffset_sec"] | 0;
   cfg.daylightOffset_sec = doc["daylightOffset_sec"] | 0;
-  cfg.sleepDuration = doc["sleepDuration"] | 60;
-  cfg.wakeupHour = doc["wakeupHour"] | 8;
-  cfg.sleepHour = doc["sleepHour"] | 23;
+  cfg.sleepDuration = doc["sleepDuration"] | kDefaultSleepDuration;
+  cfg.wakeupHour = doc["wakeupHour"] | kDefaultWakeupHour;
+  cfg.sleepHour = doc["sleepHour"] | kDefaultSleepHour;
   cfg.debugDisplayUpdate = doc["debugDisplayUpdate"] | false;
   Serial.println("Config loaded from LittleFS");
   return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,10 +111,10 @@ void DrawMoon(int x, int y, int diameter, int dd, int mm, int yy, bool southernH
 String MoonPhase(int d, int m, int y);
 void DisplayForecastSection(int x, int y);
 void DisplayGraphSection(int x, int y);
-void DisplayConditionsSection(int x, int y, const String& IconName, bool IconSize);
+void DisplayConditionsSection(int x, int y, const char* IconName, bool IconSize);
 void arrow(int x, int y, int asize, float aangle, int pwidth, int plength);
 void DrawSegment(int x, int y, int o1, int o2, int o3, int o4, int o11, int o12, int o13, int o14);
-void DrawPressureAndTrend(int x, int y, float pressure, const String& slope);
+void DrawPressureAndTrend(int x, int y, float pressure, char slope);
 void DisplayStatusSection(int x, int y, int rssi);
 void DrawRSSI(int x, int y, int rssi);
 bool UpdateLocalTime();
@@ -126,19 +126,19 @@ void addtstorm(int x, int y, int scale);
 void addsun(int x, int y, int scale, bool IconSize);
 void addfog(int x, int y, int scale, int linesize, bool IconSize);
 void DrawAngledLine(int x, int y, int x1, int y1, int size, int color);
-void ClearSky(int x, int y, bool IconSize, const String& IconName);
-void BrokenClouds(int x, int y, bool IconSize, const String& IconName);
-void FewClouds(int x, int y, bool IconSize, const String& IconName);
-void ScatteredClouds(int x, int y, bool IconSize, const String& IconName);
-void Rain(int x, int y, bool IconSize, const String& IconName);
-void ChanceRain(int x, int y, bool IconSize, const String& IconName);
-void Thunderstorms(int x, int y, bool IconSize, const String& IconName);
-void Snow(int x, int y, bool IconSize, const String& IconName);
-void Mist(int x, int y, bool IconSize, const String& IconName);
+void ClearSky(int x, int y, bool IconSize, const char* IconName);
+void BrokenClouds(int x, int y, bool IconSize, const char* IconName);
+void FewClouds(int x, int y, bool IconSize, const char* IconName);
+void ScatteredClouds(int x, int y, bool IconSize, const char* IconName);
+void Rain(int x, int y, bool IconSize, const char* IconName);
+void ChanceRain(int x, int y, bool IconSize, const char* IconName);
+void Thunderstorms(int x, int y, bool IconSize, const char* IconName);
+void Snow(int x, int y, bool IconSize, const char* IconName);
+void Mist(int x, int y, bool IconSize, const char* IconName);
 void CloudCover(int x, int y, int CloudCover);
 void Visibility(int x, int y, const String& Visibility);
 void addmoon(int x, int y, bool IconSize);
-void Nodata(int x, int y, bool IconSize, const String& IconName);
+void Nodata(int x, int y, bool IconSize, const char* IconName);
 void DrawMoonImage(int x, int y);
 void DrawSunriseImage(int x, int y);
 void DrawSunsetImage(int x, int y);
@@ -440,12 +440,10 @@ bool DecodeWeather(WiFiClient& json, const String& Type) {
   WxConditions.Winddir = current["wind_deg"];
   Serial.printf("WDir: %d\n", WxConditions.Winddir);
   JsonObject current_weather = current["weather"][0];
-  String Description = current_weather["description"];  // "scattered clouds"
-  String Icon = current_weather["icon"];                // "01n"
-  WxConditions.Forecast0 = Description;
-  Serial.printf("Fore: %s\n", WxConditions.Forecast0.c_str());
-  WxConditions.Icon = Icon;
-  Serial.printf("Icon: %s\n", WxConditions.Icon.c_str());
+  strlcpy(WxConditions.Forecast0, current_weather["description"] | "", sizeof(WxConditions.Forecast0));
+  Serial.printf("Fore: %s\n", WxConditions.Forecast0);
+  strlcpy(WxConditions.Icon, current_weather["icon"] | "", sizeof(WxConditions.Icon));
+  Serial.printf("Icon: %s\n", WxConditions.Icon);
 
   Serial.printf("\nReceiving Forecast period - ");  //------------------------------------------------
 
@@ -477,8 +475,8 @@ bool DecodeWeather(WiFiClient& json, const String& Type) {
     Serial.printf("Pres: %f\n", WxForecast[wxIndex].Pressure);
     WxForecast[wxIndex].Humidity = list[r]["humidity"].as<float>();
     Serial.printf("Humi: %f\n", WxForecast[wxIndex].Humidity);
-    WxForecast[wxIndex].Icon = list[r]["weather"][0]["icon"].as<const char*>();
-    Serial.printf("Icon: %s\n", WxForecast[wxIndex].Icon.c_str());
+    strlcpy(WxForecast[wxIndex].Icon, list[r]["weather"][0]["icon"] | "", sizeof(WxForecast[wxIndex].Icon));
+    Serial.printf("Icon: %s\n", WxForecast[wxIndex].Icon);
     WxForecast[wxIndex].Rainfall = list[r]["rain"]["1h"].as<float>();
     Serial.printf("Rain: %f\n", WxForecast[wxIndex].Rainfall);
     WxForecast[wxIndex].Snowfall = list[r]["snow"]["1h"].as<float>();
@@ -490,12 +488,12 @@ bool DecodeWeather(WiFiClient& json, const String& Type) {
     float pressure_trend =
         WxForecast[0].Pressure - WxForecast[2].Pressure;   // Measure pressure slope between ~now and later
     pressure_trend = ((int)(pressure_trend * 10)) / 10.0;  // Remove any small variations less than 0.1
-    WxConditions.Trend = "=";
-    if (pressure_trend > 0) WxConditions.Trend = "+";
-    if (pressure_trend < 0) WxConditions.Trend = "-";
-    if (pressure_trend == 0) WxConditions.Trend = "0";
+    WxConditions.Trend = '=';
+    if (pressure_trend > 0) WxConditions.Trend = '+';
+    if (pressure_trend < 0) WxConditions.Trend = '-';
+    if (pressure_trend == 0) WxConditions.Trend = '0';
   } else {
-    WxConditions.Trend = "0";  // Default if insufficient data
+    WxConditions.Trend = '0';  // Default if insufficient data
   }
   if (strcmp(cfg.units, "I") == 0) Convert_Readings_to_Imperial(wxIndex);
   return true;
@@ -868,25 +866,25 @@ void DisplayGraphSection(int x, int y) {
               max_graph_readings, autoscale_on, barchart_on);
 }
 
-void DisplayConditionsSection(int x, int y, const String& IconName, bool IconSize) {
-  Serial.printf("Icon name: %s\n", IconName.c_str());
-  if (IconName == "01d" || IconName == "01n")
+void DisplayConditionsSection(int x, int y, const char* IconName, bool IconSize) {
+  Serial.printf("Icon name: %s\n", IconName);
+  if (strcmp(IconName, "01d") == 0 || strcmp(IconName, "01n") == 0)
     ClearSky(x, y, IconSize, IconName);
-  else if (IconName == "02d" || IconName == "02n")
+  else if (strcmp(IconName, "02d") == 0 || strcmp(IconName, "02n") == 0)
     FewClouds(x, y, IconSize, IconName);
-  else if (IconName == "03d" || IconName == "03n")
+  else if (strcmp(IconName, "03d") == 0 || strcmp(IconName, "03n") == 0)
     ScatteredClouds(x, y, IconSize, IconName);
-  else if (IconName == "04d" || IconName == "04n")
+  else if (strcmp(IconName, "04d") == 0 || strcmp(IconName, "04n") == 0)
     BrokenClouds(x, y, IconSize, IconName);
-  else if (IconName == "09d" || IconName == "09n")
+  else if (strcmp(IconName, "09d") == 0 || strcmp(IconName, "09n") == 0)
     ChanceRain(x, y, IconSize, IconName);
-  else if (IconName == "10d" || IconName == "10n")
+  else if (strcmp(IconName, "10d") == 0 || strcmp(IconName, "10n") == 0)
     Rain(x, y, IconSize, IconName);
-  else if (IconName == "11d" || IconName == "11n")
+  else if (strcmp(IconName, "11d") == 0 || strcmp(IconName, "11n") == 0)
     Thunderstorms(x, y, IconSize, IconName);
-  else if (IconName == "13d" || IconName == "13n")
+  else if (strcmp(IconName, "13d") == 0 || strcmp(IconName, "13n") == 0)
     Snow(x, y, IconSize, IconName);
-  else if (IconName == "50d" || IconName == "50n")
+  else if (strcmp(IconName, "50d") == 0 || strcmp(IconName, "50n") == 0)
     Mist(x, y, IconSize, IconName);
   else
     Nodata(x, y, IconSize, IconName);
@@ -916,16 +914,16 @@ void DrawSegment(int x, int y, int o1, int o2, int o3, int o4, int o11, int o12,
   drawLine(x + o11, y + o12, x + o13, y + o14, Black);
 }
 
-void DrawPressureAndTrend(int x, int y, float pressure, const String& slope) {
+void DrawPressureAndTrend(int x, int y, float pressure, char slope) {
   const bool isMetric = (strcmp(cfg.units, "M") == 0);
   drawString(x + 25, y - 10, String(pressure, isMetric ? 0 : 1) + (isMetric ? "hPa" : "in"), LEFT);
-  if (slope == "+") {
+  if (slope == '+') {
     DrawSegment(x, y, 0, 0, 8, -8, 8, -8, 16, 0);
     DrawSegment(x - 1, y, 0, 0, 8, -8, 8, -8, 16, 0);
-  } else if (slope == "0") {
+  } else if (slope == '0') {
     DrawSegment(x, y, 8, -8, 16, 0, 8, 8, 16, 0);
     DrawSegment(x - 1, y, 8, -8, 16, 0, 8, 8, 16, 0);
-  } else if (slope == "-") {
+  } else if (slope == '-') {
     DrawSegment(x, y, 0, 0, 8, 8, 8, 8, 16, 0);
     DrawSegment(x - 1, y, 0, 0, 8, 8, 8, 8, 16, 0);
   }
@@ -1091,53 +1089,53 @@ void DrawAngledLine(int x, int y, int x1, int y1, int size, int color) {
   fillTriangle(x - dx, y + dy, x1 - dx, y1 + dy, x1 + dx, y1 - dy, color);
 }
 
-void ClearSky(int x, int y, bool IconSize, const String& IconName) {
+void ClearSky(int x, int y, bool IconSize, const char* IconName) {
   int scale = Small;
-  if (IconName.endsWith("n")) addmoon(x, y, IconSize);
+  if (IconName[2] == 'n') addmoon(x, y, IconSize);
   if (IconSize == LargeIcon) scale = Large;
   y += (IconSize ? 0 : 10);
   addsun(x, y, scale * (IconSize ? 1.7 : 1.2), IconSize);
 }
 
-void BrokenClouds(int x, int y, bool IconSize, const String& IconName) {
+void BrokenClouds(int x, int y, bool IconSize, const char* IconName) {
   int scale = Small, linesize = 5;
-  if (IconName.endsWith("n")) addmoon(x, y, IconSize);
+  if (IconName[2] == 'n') addmoon(x, y, IconSize);
   y += 15;
   if (IconSize == LargeIcon) scale = Large;
   addsun(x - scale * 1.8, y - scale * 1.8, scale, IconSize);
   addcloud(x, y, scale * (IconSize ? 1 : 0.75), linesize);
 }
 
-void FewClouds(int x, int y, bool IconSize, const String& IconName) {
+void FewClouds(int x, int y, bool IconSize, const char* IconName) {
   int scale = Small, linesize = 5;
-  if (IconName.endsWith("n")) addmoon(x, y, IconSize);
+  if (IconName[2] == 'n') addmoon(x, y, IconSize);
   y += 15;
   if (IconSize == LargeIcon) scale = Large;
   addcloud(x + (IconSize ? 10 : 0), y, scale * (IconSize ? 0.9 : 0.8), linesize);
   addsun((x + (IconSize ? 10 : 0)) - scale * 1.8, y - scale * 1.6, scale, IconSize);
 }
 
-void ScatteredClouds(int x, int y, bool IconSize, const String& IconName) {
+void ScatteredClouds(int x, int y, bool IconSize, const char* IconName) {
   int scale = Small, linesize = 5;
-  if (IconName.endsWith("n")) addmoon(x, y, IconSize);
+  if (IconName[2] == 'n') addmoon(x, y, IconSize);
   y += 15;
   if (IconSize == LargeIcon) scale = Large;
   addcloud(x - (IconSize ? 35 : 0), y - scale * 2, scale / 2, linesize);  // Cloud top left
   addcloud(x, y, scale * 0.9, linesize);                                  // Main cloud
 }
 
-void Rain(int x, int y, bool IconSize, const String& IconName) {
+void Rain(int x, int y, bool IconSize, const char* IconName) {
   int scale = Small, linesize = 5;
-  if (IconName.endsWith("n")) addmoon(x, y, IconSize);
+  if (IconName[2] == 'n') addmoon(x, y, IconSize);
   y += 15;
   if (IconSize == LargeIcon) scale = Large;
   addcloud(x, y, scale * (IconSize ? 1 : 0.75), linesize);
   addrain(x, y, scale, IconSize);
 }
 
-void ChanceRain(int x, int y, bool IconSize, const String& IconName) {
+void ChanceRain(int x, int y, bool IconSize, const char* IconName) {
   int scale = Small, linesize = 5;
-  if (IconName.endsWith("n")) addmoon(x, y, IconSize);
+  if (IconName[2] == 'n') addmoon(x, y, IconSize);
   if (IconSize == LargeIcon) scale = Large;
   y += 15;
   addsun(x - scale * 1.8, y - scale * 1.8, scale, IconSize);
@@ -1145,26 +1143,26 @@ void ChanceRain(int x, int y, bool IconSize, const String& IconName) {
   addrain(x, y, scale, IconSize);
 }
 
-void Thunderstorms(int x, int y, bool IconSize, const String& IconName) {
+void Thunderstorms(int x, int y, bool IconSize, const char* IconName) {
   int scale = Small, linesize = 5;
-  if (IconName.endsWith("n")) addmoon(x, y, IconSize);
+  if (IconName[2] == 'n') addmoon(x, y, IconSize);
   if (IconSize == LargeIcon) scale = Large;
   y += 5;
   addcloud(x, y, scale * (IconSize ? 1 : 0.75), linesize);
   addtstorm(x, y, scale);
 }
 
-void Snow(int x, int y, bool IconSize, const String& IconName) {
+void Snow(int x, int y, bool IconSize, const char* IconName) {
   int scale = Small, linesize = 5;
-  if (IconName.endsWith("n")) addmoon(x, y, IconSize);
+  if (IconName[2] == 'n') addmoon(x, y, IconSize);
   if (IconSize == LargeIcon) scale = Large;
   addcloud(x, y, scale * (IconSize ? 1 : 0.75), linesize);
   addsnow(x, y, scale, IconSize);
 }
 
-void Mist(int x, int y, bool IconSize, const String& IconName) {
+void Mist(int x, int y, bool IconSize, const char* IconName) {
   int scale = Small, linesize = 5;
-  if (IconName.endsWith("n")) addmoon(x, y, IconSize);
+  if (IconName[2] == 'n') addmoon(x, y, IconSize);
   if (IconSize == LargeIcon) scale = Large;
   addsun(x, y, scale * (IconSize ? 1 : 0.75), linesize);
   addfog(x, y, scale, linesize, IconSize);
@@ -1205,7 +1203,7 @@ void addmoon(int x, int y, bool IconSize) {
   fillCircle(x - 16 + xOffset, y - 37 + yOffset, (int)(Small * 1.6), White);
 }
 
-void Nodata(int x, int y, bool IconSize, const String& IconName) {
+void Nodata(int x, int y, bool IconSize, const char* IconName) {
   if (IconSize == LargeIcon)
     setFont(OpenSans24B);
   else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,19 @@ constexpr bool autoscale_off = false;
 constexpr bool barchart_on = true;
 constexpr bool barchart_off = false;
 
+constexpr uint8_t kGraphYDivisions = 5;   // Number of y-axis division markers
+constexpr uint8_t kGraphDashes = 20;      // Dashes per horizontal grid line
+constexpr uint8_t kGraphDaySections = 2;  // Day-boundary vertical lines
+
+struct GraphConfig {
+  int x, y, w, h;
+  float yMin, yMax;
+  const char* title;
+  bool autoscale;
+  bool barchart;
+  int readings;
+};
+
 #ifndef SIMULATOR_BUILD
 bool LargeIcon = true;
 bool SmallIcon = false;
@@ -143,8 +156,7 @@ void DrawMoonImage(int x, int y);
 void DrawSunriseImage(int x, int y);
 void DrawSunsetImage(int x, int y);
 void DrawUVI(int x, int y);
-void DrawGraph(int x_pos, int y_pos, int gwidth, int gheight, float Y1Min, float Y1Max, String title, float DataArray[],
-               int readings, bool auto_scale, bool barchart_mode);
+void DrawGraph(GraphConfig gcfg, float DataArray[]);
 void drawString(int x, int y, String text, alignment align);
 void fillCircle(int x, int y, int r, uint8_t color);
 void drawFastHLine(int16_t x0, int16_t y0, int length, uint16_t color);
@@ -851,19 +863,23 @@ void DisplayGraphSection(int x, int y) {
   int gx = (epd_width() - gwidth * 4) / 5 + 8;
   int gy = (epd_height() - gheight - 30);
   int gap = gwidth + gx;
-  // (x,y,width,height,MinValue, MaxValue, Title, Data Array, AutoScale, ChartMode)
-  DrawGraph(gx + 0 * gap, gy, gwidth, gheight, 900, 1050, isMetric ? TXT_PRESSURE_HPA : TXT_PRESSURE_IN,
-            pressure_readings, max_graph_readings, autoscale_on, barchart_off);
-  DrawGraph(gx + 1 * gap, gy, gwidth, gheight, 10, 30, isMetric ? TXT_TEMPERATURE_C : TXT_TEMPERATURE_F,
-            temperature_readings, max_graph_readings, autoscale_on, barchart_off);
-  DrawGraph(gx + 2 * gap, gy, gwidth, gheight, 0, 100, TXT_HUMIDITY_PERCENT, humidity_readings, max_graph_readings,
-            autoscale_off, barchart_off);
+  DrawGraph({gx + 0 * gap, gy, gwidth, gheight, 900, 1050,
+             isMetric ? TXT_PRESSURE_HPA.c_str() : TXT_PRESSURE_IN.c_str(), autoscale_on, barchart_off, max_graph_readings},
+            pressure_readings);
+  DrawGraph({gx + 1 * gap, gy, gwidth, gheight, 10, 30,
+             isMetric ? TXT_TEMPERATURE_C.c_str() : TXT_TEMPERATURE_F.c_str(), autoscale_on, barchart_off, max_graph_readings},
+            temperature_readings);
+  DrawGraph({gx + 2 * gap, gy, gwidth, gheight, 0, 100,
+             TXT_HUMIDITY_PERCENT.c_str(), autoscale_off, barchart_off, max_graph_readings},
+            humidity_readings);
   if (SumOfPrecip(rain_readings, max_graph_readings) >= SumOfPrecip(snow_readings, max_graph_readings))
-    DrawGraph(gx + 3 * gap + 5, gy, gwidth, gheight, 0, 30, isMetric ? TXT_RAINFALL_MM : TXT_RAINFALL_IN, rain_readings,
-              max_graph_readings, autoscale_on, barchart_on);
+    DrawGraph({gx + 3 * gap + 5, gy, gwidth, gheight, 0, 30,
+               isMetric ? TXT_RAINFALL_MM.c_str() : TXT_RAINFALL_IN.c_str(), autoscale_on, barchart_on, max_graph_readings},
+              rain_readings);
   else
-    DrawGraph(gx + 3 * gap + 5, gy, gwidth, gheight, 0, 30, isMetric ? TXT_SNOWFALL_MM : TXT_SNOWFALL_IN, snow_readings,
-              max_graph_readings, autoscale_on, barchart_on);
+    DrawGraph({gx + 3 * gap + 5, gy, gwidth, gheight, 0, 30,
+               isMetric ? TXT_SNOWFALL_MM.c_str() : TXT_SNOWFALL_IN.c_str(), autoscale_on, barchart_on, max_graph_readings},
+              snow_readings);
 }
 
 void DisplayConditionsSection(int x, int y, const char* IconName, bool IconSize) {
@@ -1242,41 +1258,29 @@ void DrawUVI(int x, int y) {
     auto_scale    - true: adjust Y axis to fit the data; false: use Y1Min/Y1Max
     barchart_mode - true: draw filled bars; false: draw a line graph
 */
-void DrawGraph(int x_pos, int y_pos, int gwidth, int gheight, float Y1Min, float Y1Max, String title, float DataArray[],
-               int readings, bool auto_scale, bool barchart_mode) {
-  constexpr float auto_scale_margin = 0;  // Sets the autoscale increment, so axis steps up after a change of e.g. 3
-  constexpr uint8_t y_minor_axis = 5;     // 5 y-axis division markers
-  setFont(OpenSans10B);
-  float maxYscale = -10000;
-  float minYscale = 10000;
-  int last_x, last_y;
-  float x2, y2;
-  if (auto_scale) {
-    for (int i = 1; i < readings; i++) {
-      if (DataArray[i] >= maxYscale) maxYscale = DataArray[i];
-      if (DataArray[i] <= minYscale) minYscale = DataArray[i];
-    }
-    maxYscale =
-        round(maxYscale +
-              auto_scale_margin);  // Auto scale the graph and round to the nearest value defined, default was Y1Max
-    Y1Max = round(maxYscale + 0.5);
-    if (minYscale != 0)
-      minYscale =
-          round(minYscale -
-                auto_scale_margin);  // Auto scale the graph and round to the nearest value defined, default was Y1Min
-    Y1Min = round(minYscale);
+static void calculateGraphYScale(const float* data, int count, float& yMin, float& yMax) {
+  yMax = -10000;
+  yMin = 10000;
+  for (int i = 1; i < count; i++) {
+    if (data[i] >= yMax) yMax = data[i];
+    if (data[i] <= yMin) yMin = data[i];
   }
-  // Draw the graph
-  last_x = x_pos + 1;
-  last_y = y_pos + (Y1Max - constrain(DataArray[0], Y1Min, Y1Max)) / (Y1Max - Y1Min) * gheight;
-  drawRect(x_pos, y_pos, gwidth + 3, gheight + 2, Grey);
-  drawString(x_pos - 20 + gwidth / 2, y_pos - 28, title, CENTER);
-  for (int gx = 0; gx < readings; gx++) {
-    x2 = x_pos + gx * gwidth / (readings - 1) -
-         1;  // max_readings is the global variable that sets the maximum data that can be plotted
-    y2 = y_pos + (Y1Max - constrain(DataArray[gx], Y1Min, Y1Max)) / (Y1Max - Y1Min) * gheight + 1;
-    if (barchart_mode) {
-      fillRect(last_x + 2, y2, (gwidth / readings) - 1, y_pos + gheight - y2 + 2, Black);
+  yMax = round(yMax + 0.5f);
+  if (yMin != 0) yMin = round(yMin);
+}
+
+void DrawGraph(GraphConfig gcfg, float DataArray[]) {
+  if (gcfg.autoscale) calculateGraphYScale(DataArray, gcfg.readings, gcfg.yMin, gcfg.yMax);
+  setFont(OpenSans10B);
+  int last_x = gcfg.x + 1;
+  int last_y = gcfg.y + (gcfg.yMax - constrain(DataArray[0], gcfg.yMin, gcfg.yMax)) / (gcfg.yMax - gcfg.yMin) * gcfg.h;
+  drawRect(gcfg.x, gcfg.y, gcfg.w + 3, gcfg.h + 2, Grey);
+  drawString(gcfg.x - 20 + gcfg.w / 2, gcfg.y - 28, gcfg.title, CENTER);
+  for (int i = 0; i < gcfg.readings; i++) {
+    float x2 = gcfg.x + i * gcfg.w / (gcfg.readings - 1) - 1;
+    float y2 = gcfg.y + (gcfg.yMax - constrain(DataArray[i], gcfg.yMin, gcfg.yMax)) / (gcfg.yMax - gcfg.yMin) * gcfg.h + 1;
+    if (gcfg.barchart) {
+      fillRect(last_x + 2, y2, (gcfg.w / gcfg.readings) - 1, gcfg.y + gcfg.h - y2 + 2, Black);
     } else {
       drawLine(last_x, last_y - 1, x2, y2 - 1, Black);  // Two lines for hi-res display
       drawLine(last_x, last_y, x2, y2, Black);
@@ -1284,32 +1288,32 @@ void DrawGraph(int x_pos, int y_pos, int gwidth, int gheight, float Y1Min, float
     last_x = x2;
     last_y = y2;
   }
-  //Draw the Y-axis scale
-  constexpr uint8_t number_of_dashes = 20;
-  for (int spacing = 0; spacing <= y_minor_axis; spacing++) {
-    for (int j = 0; j < number_of_dashes; j++) {  // Draw dashed graph grid lines
-      if (spacing < y_minor_axis)
-        drawFastHLine((x_pos + 3 + j * gwidth / number_of_dashes), y_pos + (gheight * spacing / y_minor_axis),
-                      gwidth / (2 * number_of_dashes), Grey);
+  // Draw the Y-axis scale
+  for (int spacing = 0; spacing <= kGraphYDivisions; spacing++) {
+    for (int j = 0; j < kGraphDashes; j++) {  // Draw dashed graph grid lines
+      if (spacing < kGraphYDivisions)
+        drawFastHLine((gcfg.x + 3 + j * gcfg.w / kGraphDashes), gcfg.y + (gcfg.h * spacing / kGraphYDivisions),
+                      gcfg.w / (2 * kGraphDashes), Grey);
     }
-    if ((Y1Max - (float)(Y1Max - Y1Min) / y_minor_axis * spacing) < 5 || title == TXT_PRESSURE_IN) {
-      drawString(x_pos - 10, y_pos + gheight * spacing / y_minor_axis - 5,
-                 String((Y1Max - (float)(Y1Max - Y1Min) / y_minor_axis * spacing + 0.01), 1), RIGHT);
+    float axisVal = gcfg.yMax - (float)(gcfg.yMax - gcfg.yMin) / kGraphYDivisions * spacing + 0.01f;
+    int labelX;
+    int decimalPlaces;
+    if (axisVal < 5 || strcmp(gcfg.title, TXT_PRESSURE_IN.c_str()) == 0) {
+      labelX = gcfg.x - 10;
+      decimalPlaces = 1;
+    } else if (gcfg.yMin < 1 && gcfg.yMax < 10) {
+      labelX = gcfg.x - 3;
+      decimalPlaces = 1;
     } else {
-      if (Y1Min < 1 && Y1Max < 10) {
-        drawString(x_pos - 3, y_pos + gheight * spacing / y_minor_axis - 5,
-                   String((Y1Max - (float)(Y1Max - Y1Min) / y_minor_axis * spacing + 0.01), 1), RIGHT);
-      } else {
-        drawString(x_pos - 7, y_pos + gheight * spacing / y_minor_axis - 5,
-                   String((Y1Max - (float)(Y1Max - Y1Min) / y_minor_axis * spacing + 0.01), 0), RIGHT);
-      }
+      labelX = gcfg.x - 7;
+      decimalPlaces = 0;
     }
+    drawString(labelX, gcfg.y + gcfg.h * spacing / kGraphYDivisions - 5, String(axisVal, decimalPlaces), RIGHT);
   }
-  constexpr uint8_t number_of_sections = 2;
-  for (int i = 0; i < number_of_sections; i++) {
-    drawString(20 + x_pos + gwidth / number_of_sections * i, y_pos + gheight + 10, String(i) + "d", LEFT);
+  for (int i = 0; i < kGraphDaySections; i++) {
+    drawString(20 + gcfg.x + gcfg.w / kGraphDaySections * i, gcfg.y + gcfg.h + 10, String(i) + "d", LEFT);
     if (i < 2)
-      drawFastVLine(x_pos + gwidth / number_of_sections * i + gwidth / number_of_sections, y_pos, gheight, LightGrey);
+      drawFastVLine(gcfg.x + gcfg.w / kGraphDaySections * i + gcfg.w / kGraphDaySections, gcfg.y, gcfg.h, LightGrey);
   }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,7 @@
 #include <LittleFS.h>
 #include "qrcode.h"
 #include "config.h"
+#include "defaults.h"
 #include "setup_portal.h"
 #include "forecast_record.h"
 #include "translations/lang_en.h"
@@ -185,7 +186,7 @@ void BeginSleep() {
 }
 
 bool SetupTime() {
-  configTime(cfg.gmtOffset_sec, cfg.daylightOffset_sec, cfg.ntpServer, "time.nist.gov");
+  configTime(cfg.gmtOffset_sec, cfg.daylightOffset_sec, cfg.ntpServer, kDefaultNtpFallback);
   setenv("TZ", cfg.timezone, 1);
   tzset();  // Set the TZ environment variable
   delay(100);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -960,7 +960,7 @@ bool UpdateLocalTime() {
   struct tm timeinfo;
   char time_output[30], day_output[30], update_time[30];
   while (!getLocalTime(&timeinfo, 5000)) {  // Wait for 5-sec for time to synchronise
-    Serial.println("Failed to obtain time");
+    Serial.printf("Failed to obtain time\n");
     return false;
   }
   CurrentHour = timeinfo.tm_hour;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -680,8 +680,7 @@ String WindDegToOrdinalDirection(float winddirection) {
 
 void DisplayTempHumiPressSection(int x, int y) {
   setFont(OpenSans18B);
-  drawString(x - 30, y, String(WxConditions.Temperature, 1) + "°   " + String(WxConditions.Humidity, 0) + "%",
-             LEFT);
+  drawString(x - 30, y, String(WxConditions.Temperature, 1) + "°   " + String(WxConditions.Humidity, 0) + "%", LEFT);
   setFont(OpenSans12B);
   DrawPressureAndTrend(x + 195, y + 15, WxConditions.Pressure, WxConditions.Trend);
   int Yoffset = 42;
@@ -863,23 +862,27 @@ void DisplayGraphSection(int x, int y) {
   int gx = (epd_width() - gwidth * 4) / 5 + 8;
   int gy = (epd_height() - gheight - 30);
   int gap = gwidth + gx;
-  DrawGraph({gx + 0 * gap, gy, gwidth, gheight, 900, 1050,
-             isMetric ? TXT_PRESSURE_HPA.c_str() : TXT_PRESSURE_IN.c_str(), autoscale_on, barchart_off, max_graph_readings},
-            pressure_readings);
-  DrawGraph({gx + 1 * gap, gy, gwidth, gheight, 10, 30,
-             isMetric ? TXT_TEMPERATURE_C.c_str() : TXT_TEMPERATURE_F.c_str(), autoscale_on, barchart_off, max_graph_readings},
-            temperature_readings);
-  DrawGraph({gx + 2 * gap, gy, gwidth, gheight, 0, 100,
-             TXT_HUMIDITY_PERCENT.c_str(), autoscale_off, barchart_off, max_graph_readings},
+  DrawGraph(
+      {gx + 0 * gap, gy, gwidth, gheight, 900, 1050, isMetric ? TXT_PRESSURE_HPA.c_str() : TXT_PRESSURE_IN.c_str(),
+       autoscale_on, barchart_off, max_graph_readings},
+      pressure_readings);
+  DrawGraph(
+      {gx + 1 * gap, gy, gwidth, gheight, 10, 30, isMetric ? TXT_TEMPERATURE_C.c_str() : TXT_TEMPERATURE_F.c_str(),
+       autoscale_on, barchart_off, max_graph_readings},
+      temperature_readings);
+  DrawGraph({gx + 2 * gap, gy, gwidth, gheight, 0, 100, TXT_HUMIDITY_PERCENT.c_str(), autoscale_off, barchart_off,
+             max_graph_readings},
             humidity_readings);
   if (SumOfPrecip(rain_readings, max_graph_readings) >= SumOfPrecip(snow_readings, max_graph_readings))
-    DrawGraph({gx + 3 * gap + 5, gy, gwidth, gheight, 0, 30,
-               isMetric ? TXT_RAINFALL_MM.c_str() : TXT_RAINFALL_IN.c_str(), autoscale_on, barchart_on, max_graph_readings},
-              rain_readings);
+    DrawGraph(
+        {gx + 3 * gap + 5, gy, gwidth, gheight, 0, 30, isMetric ? TXT_RAINFALL_MM.c_str() : TXT_RAINFALL_IN.c_str(),
+         autoscale_on, barchart_on, max_graph_readings},
+        rain_readings);
   else
-    DrawGraph({gx + 3 * gap + 5, gy, gwidth, gheight, 0, 30,
-               isMetric ? TXT_SNOWFALL_MM.c_str() : TXT_SNOWFALL_IN.c_str(), autoscale_on, barchart_on, max_graph_readings},
-              snow_readings);
+    DrawGraph(
+        {gx + 3 * gap + 5, gy, gwidth, gheight, 0, 30, isMetric ? TXT_SNOWFALL_MM.c_str() : TXT_SNOWFALL_IN.c_str(),
+         autoscale_on, barchart_on, max_graph_readings},
+        snow_readings);
 }
 
 void DisplayConditionsSection(int x, int y, const char* IconName, bool IconSize) {
@@ -1279,7 +1282,8 @@ void DrawGraph(GraphConfig gcfg, float DataArray[]) {
   drawString(gcfg.x - 20 + gcfg.w / 2, gcfg.y - 28, gcfg.title, CENTER);
   for (int i = 0; i < gcfg.readings; i++) {
     float x2 = gcfg.x + i * gcfg.w / (gcfg.readings - 1) - 1;
-    float y2 = gcfg.y + (gcfg.yMax - constrain(DataArray[i], gcfg.yMin, gcfg.yMax)) / (gcfg.yMax - gcfg.yMin) * gcfg.h + 1;
+    float y2 =
+        gcfg.y + (gcfg.yMax - constrain(DataArray[i], gcfg.yMin, gcfg.yMax)) / (gcfg.yMax - gcfg.yMin) * gcfg.h + 1;
     if (gcfg.barchart) {
       fillRect(last_x + 2, y2, (gcfg.w / gcfg.readings) - 1, gcfg.y + gcfg.h - y2 + 2, Black);
     } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -281,8 +281,8 @@ void setup() {
       byte Attempts = 1;
       bool RxWeather = false;
       WiFiClient client;
-      while ((RxWeather == false) && Attempts <= 2) {
-        if (RxWeather == false) RxWeather = obtainWeatherData(client, "onecall");
+      while (!RxWeather && Attempts <= 2) {
+        if (!RxWeather) RxWeather = obtainWeatherData(client, "onecall");
         Attempts++;
       }
       StopWiFi();
@@ -1253,7 +1253,7 @@ void DrawGraph(int x_pos, int y_pos, int gwidth, int gheight, float Y1Min, float
   float minYscale = 10000;
   int last_x, last_y;
   float x2, y2;
-  if (auto_scale == true) {
+  if (auto_scale) {
     for (int i = 1; i < readings; i++) {
       if (DataArray[i] >= maxYscale) maxYscale = DataArray[i];
       if (DataArray[i] <= minYscale) minYscale = DataArray[i];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -198,14 +198,14 @@ uint8_t StartWiFi() {
     wifi_signal = WiFi.RSSI();  // Get Wifi Signal strength now, because the WiFi will be turned off to save power!
     Serial.printf("WiFi connected at: %s\n", WiFi.localIP().toString().c_str());
   } else
-    Serial.println("WiFi connection *** FAILED ***");
+    Serial.printf("WiFi connection *** FAILED ***\n");
   return WiFi.status();
 }
 
 void StopWiFi() {
   WiFi.disconnect();
   WiFi.mode(WIFI_OFF);
-  Serial.println("WiFi switched Off");
+  Serial.printf("WiFi switched Off\n");
 }
 
 void InitialiseSystem() {
@@ -286,7 +286,7 @@ void setup() {
         if (RxWeather == false) RxWeather = obtainWeatherData(client, "onecall");
         Attempts++;
       }
-      Serial.println("Received all weather data...");
+      Serial.printf("Received all weather data...\n");
       if (RxWeather) {
         StopWiFi();
         epd_poweron();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,7 +45,7 @@ int wifi_signal, CurrentHour = 0, CurrentMin = 0, CurrentSec = 0, vref = 1100;
 constexpr uint8_t max_readings = 24;  // Limited to 3-days here, but could go to 5-days = 40 as the data is issued
 constexpr uint8_t max_graph_readings = 16;
 
-Forecast_record_type WxConditions[1];
+Forecast_record_type WxConditions;
 Forecast_record_type WxForecast[max_readings];
 
 float pressure_readings[max_readings] = {0};
@@ -182,7 +182,6 @@ bool SetupTime() {
 
 uint8_t StartWiFi() {
   Serial.printf("\r\nConnecting to: %s\n", cfg.ssid);
-  IPAddress dns(8, 8, 8, 8);  // Use Google DNS
   WiFi.disconnect();
   WiFi.mode(WIFI_STA);  // switch off AP
   WiFi.setAutoConnect(true);
@@ -286,14 +285,16 @@ void setup() {
         if (RxWeather == false) RxWeather = obtainWeatherData(client, "onecall");
         Attempts++;
       }
-      Serial.printf("Received all weather data...\n");
+      StopWiFi();
       if (RxWeather) {
-        StopWiFi();
+        Serial.printf("Received all weather data, updating display...\n");
         epd_poweron();
         epd_fullclear(&hl, (int)epd_ambient_temperature());
         DisplayWeather();
         edp_update();
         epd_poweroff();
+      } else {
+        Serial.printf("Failed to receive weather data, skipping display update.\n");
       }
     }
   }
@@ -394,7 +395,7 @@ void DisplaySetupScreen(const char* apName) {
 #endif  // SIMULATOR_BUILD
 
 void Convert_Readings_to_Imperial(int count) {
-  WxConditions[0].Pressure = hPa_to_inHg(WxConditions[0].Pressure);
+  WxConditions.Pressure = hPa_to_inHg(WxConditions.Pressure);
   for (int i = 0; i < count; i++) {
     WxForecast[i].Rainfall = mm_to_inches(WxForecast[i].Rainfall);
     WxForecast[i].Snowfall = mm_to_inches(WxForecast[i].Snowfall);
@@ -413,49 +414,49 @@ bool DecodeWeather(WiFiClient& json, const String& Type) {
   // convert it to a JsonObject
   JsonObject root = doc.as<JsonObject>();
   Serial.printf(" Decoding %s data\n", Type.c_str());
-  WxConditions[0].High = -50;  // Sentinel: replaced by daily[0] max below
-  WxConditions[0].Low = 50;    // Sentinel: replaced by daily[0] min below
+  WxConditions.High = -50;  // Sentinel: replaced by daily[0] max below
+  WxConditions.Low = 50;    // Sentinel: replaced by daily[0] min below
   JsonObject current = doc["current"];
-  WxConditions[0].Sunrise = current["sunrise"];
-  Serial.printf("SRis: %d\n", WxConditions[0].Sunrise);
-  WxConditions[0].Sunset = current["sunset"];
-  Serial.printf("SSet: %d\n", WxConditions[0].Sunset);
-  WxConditions[0].Temperature = current["temp"];
-  Serial.printf("Temp: %f\n", WxConditions[0].Temperature);
-  WxConditions[0].FeelsLike = current["feels_like"];
-  Serial.printf("FLik: %f\n", WxConditions[0].FeelsLike);
-  WxConditions[0].Pressure = current["pressure"];
-  Serial.printf("Pres: %f\n", WxConditions[0].Pressure);
-  WxConditions[0].Humidity = current["humidity"];
-  Serial.printf("Humi: %f\n", WxConditions[0].Humidity);
-  WxConditions[0].DewPoint = current["dew_point"];
-  Serial.printf("DPoi: %f\n", WxConditions[0].DewPoint);
-  WxConditions[0].UVI = current["uvi"];
-  Serial.printf("UVin: %f\n", WxConditions[0].UVI);
-  WxConditions[0].Cloudcover = current["clouds"];
-  Serial.printf("CCov: %d\n", WxConditions[0].Cloudcover);
-  WxConditions[0].Visibility = current["visibility"];
-  Serial.printf("Visi: %d\n", WxConditions[0].Visibility);
-  WxConditions[0].Windspeed = current["wind_speed"];
-  Serial.printf("WSpd: %f\n", WxConditions[0].Windspeed);
-  WxConditions[0].Winddir = current["wind_deg"];
-  Serial.printf("WDir: %d\n", WxConditions[0].Winddir);
+  WxConditions.Sunrise = current["sunrise"];
+  Serial.printf("SRis: %d\n", WxConditions.Sunrise);
+  WxConditions.Sunset = current["sunset"];
+  Serial.printf("SSet: %d\n", WxConditions.Sunset);
+  WxConditions.Temperature = current["temp"];
+  Serial.printf("Temp: %f\n", WxConditions.Temperature);
+  WxConditions.FeelsLike = current["feels_like"];
+  Serial.printf("FLik: %f\n", WxConditions.FeelsLike);
+  WxConditions.Pressure = current["pressure"];
+  Serial.printf("Pres: %f\n", WxConditions.Pressure);
+  WxConditions.Humidity = current["humidity"];
+  Serial.printf("Humi: %f\n", WxConditions.Humidity);
+  WxConditions.DewPoint = current["dew_point"];
+  Serial.printf("DPoi: %f\n", WxConditions.DewPoint);
+  WxConditions.UVI = current["uvi"];
+  Serial.printf("UVin: %f\n", WxConditions.UVI);
+  WxConditions.Cloudcover = current["clouds"];
+  Serial.printf("CCov: %d\n", WxConditions.Cloudcover);
+  WxConditions.Visibility = current["visibility"];
+  Serial.printf("Visi: %d\n", WxConditions.Visibility);
+  WxConditions.Windspeed = current["wind_speed"];
+  Serial.printf("WSpd: %f\n", WxConditions.Windspeed);
+  WxConditions.Winddir = current["wind_deg"];
+  Serial.printf("WDir: %d\n", WxConditions.Winddir);
   JsonObject current_weather = current["weather"][0];
   String Description = current_weather["description"];  // "scattered clouds"
   String Icon = current_weather["icon"];                // "01n"
-  WxConditions[0].Forecast0 = Description;
-  Serial.printf("Fore: %s\n", WxConditions[0].Forecast0.c_str());
-  WxConditions[0].Icon = Icon;
-  Serial.printf("Icon: %s\n", WxConditions[0].Icon.c_str());
+  WxConditions.Forecast0 = Description;
+  Serial.printf("Fore: %s\n", WxConditions.Forecast0.c_str());
+  WxConditions.Icon = Icon;
+  Serial.printf("Icon: %s\n", WxConditions.Icon.c_str());
 
   Serial.printf("\nReceiving Forecast period - ");  //------------------------------------------------
 
   // Daily
   JsonArray daily = root["daily"];
-  WxConditions[0].Low = daily[0]["temp"]["min"].as<float>();  // Get Lowest temperature for next 24Hrs
-  Serial.printf("TLow: %f\n", WxConditions[0].Low);
-  WxConditions[0].High = daily[0]["temp"]["max"].as<float>();  // Get Highest temperature for next 24Hrs
-  Serial.printf("High: %f\n", WxConditions[0].High);
+  WxConditions.Low = daily[0]["temp"]["min"].as<float>();  // Get Lowest temperature for next 24Hrs
+  Serial.printf("TLow: %f\n", WxConditions.Low);
+  WxConditions.High = daily[0]["temp"]["max"].as<float>();  // Get Highest temperature for next 24Hrs
+  Serial.printf("High: %f\n", WxConditions.High);
 
   //TODO: daily[1..7] has 7 more days of temp/icon/description data — add a weekly forecast row if screen space allows
 
@@ -485,20 +486,18 @@ bool DecodeWeather(WiFiClient& json, const String& Type) {
     WxForecast[wxIndex].Snowfall = list[r]["snow"]["1h"].as<float>();
     Serial.printf("Snow: %f\n", WxForecast[wxIndex].Snowfall);
 
-    //------------------------------------------
-    if (wxIndex >= 2) {
-      float pressure_trend =
-          WxForecast[0].Pressure - WxForecast[2].Pressure;   // Measure pressure slope between ~now and later
-      pressure_trend = ((int)(pressure_trend * 10)) / 10.0;  // Remove any small variations less than 0.1
-      WxConditions[0].Trend = "=";
-      if (pressure_trend > 0) WxConditions[0].Trend = "+";
-      if (pressure_trend < 0) WxConditions[0].Trend = "-";
-      if (pressure_trend == 0) WxConditions[0].Trend = "0";
-    } else {
-      WxConditions[0].Trend = "0";  // Default if insufficient data
-    }
-
     wxIndex++;  // Increment WxForecast index for sequential population
+  }
+  if (wxIndex >= 3) {
+    float pressure_trend =
+        WxForecast[0].Pressure - WxForecast[2].Pressure;   // Measure pressure slope between ~now and later
+    pressure_trend = ((int)(pressure_trend * 10)) / 10.0;  // Remove any small variations less than 0.1
+    WxConditions.Trend = "=";
+    if (pressure_trend > 0) WxConditions.Trend = "+";
+    if (pressure_trend < 0) WxConditions.Trend = "-";
+    if (pressure_trend == 0) WxConditions.Trend = "0";
+  } else {
+    WxConditions.Trend = "0";  // Default if insufficient data
   }
   if (strcmp(cfg.units, "I") == 0) Convert_Readings_to_Imperial(wxIndex);
   return true;
@@ -587,7 +586,7 @@ String TitleCase(const String& text) {
 void DisplayWeather() {                        // 4.7" e-paper display is 960x540 resolution
   DisplayStatusSection(600, 20, wifi_signal);  // Wi-Fi signal strength and Battery voltage
   DisplayGeneralInfoSection();                 // Top line of the display
-  DisplayWindSection(137, 150, WxConditions[0].Winddir, WxConditions[0].Windspeed, 100);
+  DisplayWindSection(137, 150, WxConditions.Winddir, WxConditions.Windspeed, 100);
   DisplayAstronomySection(5, 252);  // Astronomy section Sun rise/set, Moon phase and Moon icon
   DisplayMainWeatherSection(
       320, 110);  // Centre section of display for Location, temperature, Weather report, current Wx Symbol
@@ -604,7 +603,7 @@ void DisplayGeneralInfoSection() {
 }
 
 void DisplayWeatherIcon(int x, int y) {
-  DisplayConditionsSection(x, y, WxConditions[0].Icon, LargeIcon);
+  DisplayConditionsSection(x, y, WxConditions.Icon, LargeIcon);
 }
 
 void DisplayMainWeatherSection(int x, int y) {
@@ -673,17 +672,17 @@ String WindDegToOrdinalDirection(float winddirection) {
 
 void DisplayTempHumiPressSection(int x, int y) {
   setFont(OpenSans18B);
-  drawString(x - 30, y, String(WxConditions[0].Temperature, 1) + "°   " + String(WxConditions[0].Humidity, 0) + "%",
+  drawString(x - 30, y, String(WxConditions.Temperature, 1) + "°   " + String(WxConditions.Humidity, 0) + "%",
              LEFT);
   setFont(OpenSans12B);
-  DrawPressureAndTrend(x + 195, y + 15, WxConditions[0].Pressure, WxConditions[0].Trend);
+  DrawPressureAndTrend(x + 195, y + 15, WxConditions.Pressure, WxConditions.Trend);
   int Yoffset = 42;
-  if (WxConditions[0].Windspeed > 0) {
-    drawString(x - 30, y + Yoffset, String(WxConditions[0].FeelsLike, 1) + "° FL",
+  if (WxConditions.Windspeed > 0) {
+    drawString(x - 30, y + Yoffset, String(WxConditions.FeelsLike, 1) + "° FL",
                LEFT);  // Show FeelsLike temperature if windspeed > 0
     Yoffset += 30;
   }
-  drawString(x - 30, y + Yoffset, String(WxConditions[0].High, 0) + "° | " + String(WxConditions[0].Low, 0) + "° Hi/Lo",
+  drawString(x - 30, y + Yoffset, String(WxConditions.High, 0) + "° | " + String(WxConditions.Low, 0) + "° Hi/Lo",
              LEFT);  // Show forecast high and Low
 }
 
@@ -691,7 +690,7 @@ void DisplayForecastTextSection(int x, int y) {
   constexpr uint8_t lineWidth = 34;
   const bool isMetric = (strcmp(cfg.units, "M") == 0);
   setFont(OpenSans12B);
-  String Wx_Description = WxConditions[0].Forecast0;
+  String Wx_Description = WxConditions.Forecast0;
   Wx_Description.replace(".", "");  // remove any '.'
   int spaceRemaining = 0, p = 0, charCount = 0;
   while (p < Wx_Description.length()) {
@@ -714,9 +713,9 @@ void DisplayForecastTextSection(int x, int y) {
 
 void DisplayVisiCCoverUVISection(int x, int y) {
   setFont(OpenSans12B);
-  Visibility(x + 5, y, String(WxConditions[0].Visibility) + "M");
-  CloudCover(x + 155, y, WxConditions[0].Cloudcover);
-  Display_UVIndexLevel(x + 265, y, WxConditions[0].UVI);
+  Visibility(x + 5, y, String(WxConditions.Visibility) + "M");
+  CloudCover(x + 155, y, WxConditions.Cloudcover);
+  Display_UVIndexLevel(x + 265, y, WxConditions.UVI);
 }
 
 void Display_UVIndexLevel(int x, int y, float UVI) {
@@ -752,8 +751,8 @@ void DisplayAstronomySection(int x, int y) {
   DrawMoonImage(x + 10, y + 23);  // Different references!
   DrawMoon(x - 28, y - 15, 75, now_utc->tm_mday, now_utc->tm_mon + 1, now_utc->tm_year + 1900,
            isSouthernHemisphere());  // Spaced at 1/2 moon size, so 10 - 75/2 = -28
-  drawString(x + 115, y + 40, ConvertUnixTime(WxConditions[0].Sunrise).substring(0, 5), LEFT);  // Sunrise
-  drawString(x + 115, y + 80, ConvertUnixTime(WxConditions[0].Sunset).substring(0, 5), LEFT);   // Sunset
+  drawString(x + 115, y + 40, ConvertUnixTime(WxConditions.Sunrise).substring(0, 5), LEFT);  // Sunrise
+  drawString(x + 115, y + 80, ConvertUnixTime(WxConditions.Sunset).substring(0, 5), LEFT);   // Sunset
   DrawSunriseImage(x + 180, y + 20);
   DrawSunsetImage(x + 180, y + 60);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -411,8 +411,6 @@ bool DecodeWeather(WiFiClient& json, const String& Type) {
     Serial.printf("deserializeJson() failed: %s\n", error.c_str());
     return false;
   }
-  // convert it to a JsonObject
-  JsonObject root = doc.as<JsonObject>();
   Serial.printf(" Decoding %s data\n", Type.c_str());
   WxConditions.High = -50;  // Sentinel: replaced by daily[0] max below
   WxConditions.Low = 50;    // Sentinel: replaced by daily[0] min below
@@ -452,7 +450,7 @@ bool DecodeWeather(WiFiClient& json, const String& Type) {
   Serial.printf("\nReceiving Forecast period - ");  //------------------------------------------------
 
   // Daily
-  JsonArray daily = root["daily"];
+  JsonArray daily = doc["daily"];
   WxConditions.Low = daily[0]["temp"]["min"].as<float>();  // Get Lowest temperature for next 24Hrs
   Serial.printf("TLow: %f\n", WxConditions.Low);
   WxConditions.High = daily[0]["temp"]["max"].as<float>();  // Get Highest temperature for next 24Hrs
@@ -460,7 +458,7 @@ bool DecodeWeather(WiFiClient& json, const String& Type) {
 
   //TODO: daily[1..7] has 7 more days of temp/icon/description data — add a weekly forecast row if screen space allows
 
-  JsonArray list = root["hourly"];
+  JsonArray list = doc["hourly"];
   byte wxIndex = 0;                                      // Index to populate WxForecast sequentially
   Serial.printf("hourly list size: %u\n", list.size());  // 48 hours of hourly data is returned by the API
   for (byte r = 0; r < 48 && wxIndex < 16; r += 3) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,7 +54,7 @@ constexpr uint8_t Large = 20;  // For icon drawing
 constexpr uint8_t Small = 10;  // For icon drawing
 String Time_str = "--:--:--";
 String Date_str = "-- --- ----";
-int wifi_signal, CurrentHour = 0, CurrentMin = 0, CurrentSec = 0, vref = 1100;
+int wifi_signal, CurrentHour = 0, CurrentMin = 0, CurrentSec = 0, vref = kDefaultVref;
 //################ PROGRAM VARIABLES and OBJECTS ##########################################
 constexpr uint8_t max_readings = 24;  // Limited to 3-days here, but could go to 5-days = 40 as the data is issued
 constexpr uint8_t max_graph_readings = 16;
@@ -592,16 +592,15 @@ String TitleCase(const String& text) {
     return text;
 }
 
-void DisplayWeather() {                        // 4.7" e-paper display is 960x540 resolution
-  DisplayStatusSection(600, 20, wifi_signal);  // Wi-Fi signal strength and Battery voltage
-  DisplayGeneralInfoSection();                 // Top line of the display
-  DisplayWindSection(137, 150, WxConditions.Winddir, WxConditions.Windspeed, 100);
-  DisplayAstronomySection(5, 252);  // Astronomy section Sun rise/set, Moon phase and Moon icon
-  DisplayMainWeatherSection(
-      320, 110);  // Centre section of display for Location, temperature, Weather report, current Wx Symbol
-  DisplayWeatherIcon(835, 140);      // Display weather icon scale = Large;
-  DisplayForecastSection(285, 220);  // 3hr forecast boxes
-  DisplayGraphSection(320, 220);     // Graphs of pressure, temperature, humidity and rain or snowfall
+void DisplayWeather() {  // 4.7" e-paper display is 960x540 resolution
+  DisplayStatusSection(kLayoutStatusX, kLayoutStatusY, wifi_signal);
+  DisplayGeneralInfoSection();
+  DisplayWindSection(kLayoutWindX, kLayoutWindY, WxConditions.Winddir, WxConditions.Windspeed, kLayoutWindRadius);
+  DisplayAstronomySection(kLayoutAstronomyX, kLayoutAstronomyY);
+  DisplayMainWeatherSection(kLayoutMainWeatherX, kLayoutMainWeatherY);
+  DisplayWeatherIcon(kLayoutWeatherIconX, kLayoutWeatherIconY);
+  DisplayForecastSection(kLayoutForecastX, kLayoutForecastY);
+  DisplayGraphSection(kLayoutGraphX, kLayoutGraphY);
 }
 
 void DisplayGeneralInfoSection() {
@@ -1001,12 +1000,13 @@ void DrawBattery(int x, int y) {
   uint8_t percentage = 100;
   esp_adc_cal_characteristics_t adc_chars;
   esp_adc_cal_value_t val_type =
-      esp_adc_cal_characterize(ADC_UNIT_1, ADC_ATTEN_DB_12, ADC_WIDTH_BIT_12, 1100, &adc_chars);
+      esp_adc_cal_characterize(ADC_UNIT_1, ADC_ATTEN_DB_12, ADC_WIDTH_BIT_12, kDefaultVref, &adc_chars);
   if (val_type == ESP_ADC_CAL_VAL_EFUSE_VREF) {
     Serial.printf("eFuse Vref:%u mV", adc_chars.vref);
     vref = adc_chars.vref;
   }
-  float voltage = analogRead(36) / 4096.0 * 6.566 * (vref / 1000.0);
+  // kBatteryVoltageDiv is the resistor divider ratio on ADC pin kBatteryAdcPin
+  float voltage = analogRead(kBatteryAdcPin) / (float)kBatteryAdcBits * kBatteryVoltageDiv * (vref / 1000.0);
   if (voltage > 1) {  // Only display if there is a valid reading
     Serial.printf("\nVoltage = %.2f\n", voltage);
     percentage = 2836.9625 * pow(voltage, 4) - 43987.4889 * pow(voltage, 3) + 255233.8134 * pow(voltage, 2) -

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -186,25 +186,25 @@ void BeginSleep() {
 }
 
 bool SetupTime() {
-  configTime(cfg.gmtOffset_sec, cfg.daylightOffset_sec, cfg.ntpServer, kDefaultNtpFallback);
-  setenv("TZ", cfg.timezone, 1);
+  configTime(cfg.gmtOffset_sec, cfg.daylightOffset_sec, cfg.ntpServer.c_str(), kDefaultNtpFallback);
+  setenv("TZ", cfg.timezone.c_str(), 1);
   tzset();  // Set the TZ environment variable
   delay(100);
   return UpdateLocalTime();
 }
 
 uint8_t StartWiFi() {
-  Serial.printf("\r\nConnecting to: %s\n", cfg.ssid);
+  Serial.printf("\r\nConnecting to: %s\n", cfg.ssid.c_str());
   WiFi.disconnect();
   WiFi.mode(WIFI_STA);  // switch off AP
   WiFi.setAutoConnect(true);
   WiFi.setAutoReconnect(true);
-  WiFi.begin(cfg.ssid, cfg.password);
+  WiFi.begin(cfg.ssid.c_str(), cfg.password.c_str());
   if (WiFi.waitForConnectResult() != WL_CONNECTED) {
     Serial.println("STA: Failed!");
     WiFi.disconnect(false);
     delay(500);
-    WiFi.begin(cfg.ssid, cfg.password);
+    WiFi.begin(cfg.ssid.c_str(), cfg.password.c_str());
   }
   if (WiFi.status() == WL_CONNECTED) {
     wifi_signal = WiFi.RSSI();  // Get Wifi Signal strength now, because the WiFi will be turned off to save power!
@@ -508,7 +508,7 @@ bool DecodeWeather(WiFiClient& json, const String& Type) {
   } else {
     WxConditions.Trend = '0';  // Default if insufficient data
   }
-  if (strcmp(cfg.units, "I") == 0) Convert_Readings_to_Imperial(wxIndex);
+  if (cfg.units == "I") Convert_Readings_to_Imperial(wxIndex);
   return true;
 }
 #endif  // SIMULATOR_BUILD
@@ -516,7 +516,7 @@ bool DecodeWeather(WiFiClient& json, const String& Type) {
 //#########################################################################################
 String ConvertUnixTime(int unix_time) {
   // Returns either '21:12  ' or ' 09:12pm' depending on Units mode
-  const bool isMetric = (strcmp(cfg.units, "M") == 0);
+  const bool isMetric = (cfg.units == "M");
   time_t tm = unix_time + cfg.gmtOffset_sec + cfg.daylightOffset_sec;
   struct tm* now_tm = gmtime(&tm);
   char output[40];
@@ -530,15 +530,15 @@ String ConvertUnixTime(int unix_time) {
 //#########################################################################################
 #ifndef SIMULATOR_BUILD
 bool obtainWeatherData(WiFiClient& client, const String& RequestType) {
-  const bool isMetric = (strcmp(cfg.units, "M") == 0);
+  const bool isMetric = (cfg.units == "M");
   const String units = (isMetric ? "metric" : "imperial");
   client.stop();  // close connection before sending a new request
   HTTPClient http;
   //api.openweathermap.org/data/3.0/onecall?lat={lat}&lon={lon}&appid={API key}
-  String uri = "/data/3.0/" + RequestType + "?lat=" + cfg.latitude + "&lon=" + cfg.longitude + "&appid=" + cfg.apikey +
-               "&mode=json&units=" + units + "&lang=" + cfg.language;
+  String uri = "/data/3.0/" + RequestType + "?lat=" + cfg.latitude.c_str() + "&lon=" + cfg.longitude.c_str() +
+               "&appid=" + cfg.apikey.c_str() + "&mode=json&units=" + units + "&lang=" + cfg.language.c_str();
   if (RequestType == "onecall") uri += "&exclude=minutely,alerts";
-  http.begin(client, cfg.server, 80, uri);
+  http.begin(client, cfg.server.c_str(), 80, uri);
   int httpCode = http.GET();
   if (httpCode == HTTP_CODE_OK) {
     if (!DecodeWeather(http.getStream(), RequestType)) return false;
@@ -605,7 +605,7 @@ void DisplayWeather() {  // 4.7" e-paper display is 960x540 resolution
 
 void DisplayGeneralInfoSection() {
   setFont(OpenSans10B);
-  drawString(5, 2, String(cfg.city), LEFT);
+  drawString(5, 2, String(cfg.city.c_str()), LEFT);
   setFont(OpenSans8B);
   drawString(500, 2, Date_str + "  @   " + Time_str, LEFT);
 }
@@ -654,7 +654,7 @@ void DisplayWindSection(int x, int y, float angle, float windspeed, int Cradius)
   setFont(OpenSans24B);
   drawString(x + 3, y - 18, String(windspeed, 1), CENTER);
   setFont(OpenSans12B);
-  const bool isMetric = (strcmp(cfg.units, "M") == 0);
+  const bool isMetric = (cfg.units == "M");
   drawString(x, y + 25, (isMetric ? "m/s" : "mph"), CENTER);
 }
 
@@ -695,7 +695,7 @@ void DisplayTempHumiPressSection(int x, int y) {
 
 void DisplayForecastTextSection(int x, int y) {
   constexpr uint8_t lineWidth = 34;
-  const bool isMetric = (strcmp(cfg.units, "M") == 0);
+  const bool isMetric = (cfg.units == "M");
   setFont(OpenSans12B);
   String Wx_Description = WxConditions.Forecast0;
   Wx_Description.replace(".", "");  // remove any '.'
@@ -747,7 +747,7 @@ void DisplayForecastWeather(int x, int y, int index, int fwidth) {
 
 
 static inline bool isSouthernHemisphere() {
-  return atof(cfg.latitude) < 0.0;
+  return atof(cfg.latitude.c_str()) < 0.0;
 }
 
 void DisplayAstronomySection(int x, int y) {
@@ -848,7 +848,7 @@ void DisplayForecastSection(int x, int y) {
 }
 
 void DisplayGraphSection(int x, int y) {
-  const bool isMetric = (strcmp(cfg.units, "M") == 0);
+  const bool isMetric = (cfg.units == "M");
   int r = 0;
   do {  // Pre-load temporary arrays with data — values already in display units after DecodeWeather
     pressure_readings[r] = WxForecast[r].Pressure;
@@ -934,7 +934,7 @@ void DrawSegment(int x, int y, int o1, int o2, int o3, int o4, int o11, int o12,
 }
 
 void DrawPressureAndTrend(int x, int y, float pressure, char slope) {
-  const bool isMetric = (strcmp(cfg.units, "M") == 0);
+  const bool isMetric = (cfg.units == "M");
   drawString(x + 25, y - 10, String(pressure, isMetric ? 0 : 1) + (isMetric ? "hPa" : "in"), LEFT);
   if (slope == '+') {
     DrawSegment(x, y, 0, 0, 8, -8, 8, -8, 16, 0);
@@ -970,7 +970,7 @@ void DrawRSSI(int x, int y, int rssi) {
 
 #ifndef SIMULATOR_BUILD
 bool UpdateLocalTime() {
-  const bool isMetric = (strcmp(cfg.units, "M") == 0);
+  const bool isMetric = (cfg.units == "M");
   struct tm timeinfo;
   char time_output[30], day_output[30], update_time[30];
   while (!getLocalTime(&timeinfo, 5000)) {  // Wait for 5-sec for time to synchronise

--- a/src/setup_portal.cpp
+++ b/src/setup_portal.cpp
@@ -105,25 +105,25 @@ static void handleRoot() {
 
 // Reject and respond 400 if the named form field exceeds the target buffer.
 // String::toCharArray() does not null-terminate when src >= dest size.
-#define CHECK_FIELD_LEN(name, buf)                                        \
-  if (httpServer.arg(name).length() >= sizeof(buf)) {                     \
-    httpServer.send(400, "text/plain", "Field too long: " name);          \
-    return;                                                                \
+#define CHECK_FIELD_LEN(name, buf)                               \
+  if (httpServer.arg(name).length() >= sizeof(buf)) {            \
+    httpServer.send(400, "text/plain", "Field too long: " name); \
+    return;                                                      \
   }
 
 static void handleSave() {
   auto arg = [](const char* n) { return httpServer.arg(n); };
 
-  CHECK_FIELD_LEN("ssid",          cfg.ssid)
-  CHECK_FIELD_LEN("apikey",        cfg.apikey)
-  CHECK_FIELD_LEN("server",        cfg.server)
-  CHECK_FIELD_LEN("city",          cfg.city)
-  CHECK_FIELD_LEN("latitude",      cfg.latitude)
-  CHECK_FIELD_LEN("longitude",     cfg.longitude)
-  CHECK_FIELD_LEN("language",      cfg.language)
-  CHECK_FIELD_LEN("units",         cfg.units)
-  CHECK_FIELD_LEN("timezone",      cfg.timezone)
-  CHECK_FIELD_LEN("ntpServer",     cfg.ntpServer)
+  CHECK_FIELD_LEN("ssid", cfg.ssid)
+  CHECK_FIELD_LEN("apikey", cfg.apikey)
+  CHECK_FIELD_LEN("server", cfg.server)
+  CHECK_FIELD_LEN("city", cfg.city)
+  CHECK_FIELD_LEN("latitude", cfg.latitude)
+  CHECK_FIELD_LEN("longitude", cfg.longitude)
+  CHECK_FIELD_LEN("language", cfg.language)
+  CHECK_FIELD_LEN("units", cfg.units)
+  CHECK_FIELD_LEN("timezone", cfg.timezone)
+  CHECK_FIELD_LEN("ntpServer", cfg.ntpServer)
 
   arg("ssid").toCharArray(cfg.ssid, sizeof(cfg.ssid));
 

--- a/src/setup_portal.cpp
+++ b/src/setup_portal.cpp
@@ -76,7 +76,9 @@ static void handleConfigJson() {
 #ifndef REDACT_PASSWORD_IN_CONFIG_DOWNLOAD
   doc["password"] = cfg.password;
 #endif
+#ifndef REDACT_APIKEY_IN_CONFIG_DOWNLOAD
   doc["apikey"] = cfg.apikey;
+#endif
   doc["server"] = cfg.server;
   doc["city"] = cfg.city;
   doc["latitude"] = cfg.latitude;
@@ -101,14 +103,39 @@ static void handleRoot() {
   httpServer.send(200, "text/html", buildPage());
 }
 
+// Reject and respond 400 if the named form field exceeds the target buffer.
+// String::toCharArray() does not null-terminate when src >= dest size.
+#define CHECK_FIELD_LEN(name, buf)                                        \
+  if (httpServer.arg(name).length() >= sizeof(buf)) {                     \
+    httpServer.send(400, "text/plain", "Field too long: " name);          \
+    return;                                                                \
+  }
+
 static void handleSave() {
   auto arg = [](const char* n) { return httpServer.arg(n); };
+
+  CHECK_FIELD_LEN("ssid",          cfg.ssid)
+  CHECK_FIELD_LEN("apikey",        cfg.apikey)
+  CHECK_FIELD_LEN("server",        cfg.server)
+  CHECK_FIELD_LEN("city",          cfg.city)
+  CHECK_FIELD_LEN("latitude",      cfg.latitude)
+  CHECK_FIELD_LEN("longitude",     cfg.longitude)
+  CHECK_FIELD_LEN("language",      cfg.language)
+  CHECK_FIELD_LEN("units",         cfg.units)
+  CHECK_FIELD_LEN("timezone",      cfg.timezone)
+  CHECK_FIELD_LEN("ntpServer",     cfg.ntpServer)
 
   arg("ssid").toCharArray(cfg.ssid, sizeof(cfg.ssid));
 
   // Only overwrite password if user typed something
   String pw = arg("password");
-  if (pw.length() > 0) pw.toCharArray(cfg.password, sizeof(cfg.password));
+  if (pw.length() > 0) {
+    if (pw.length() >= sizeof(cfg.password)) {
+      httpServer.send(400, "text/plain", "Field too long: password");
+      return;
+    }
+    pw.toCharArray(cfg.password, sizeof(cfg.password));
+  }
 
   arg("apikey").toCharArray(cfg.apikey, sizeof(cfg.apikey));
   arg("server").toCharArray(cfg.server, sizeof(cfg.server));
@@ -133,6 +160,8 @@ static void handleSave() {
   delay(1000);
   ESP.restart();
 }
+
+#undef CHECK_FIELD_LEN
 
 // ---------------------------------------------------------------------------
 // OTA update handlers

--- a/src/setup_portal.cpp
+++ b/src/setup_portal.cpp
@@ -16,10 +16,10 @@ static DNSServer dnsServer;
 // Helpers
 // ---------------------------------------------------------------------------
 
-static String htmlEscape(const char* s) {
+static String htmlEscape(const std::string& s) {
   String out;
-  for (const char* p = s; *p; p++) {
-    switch (*p) {
+  for (char c : s) {
+    switch (c) {
       case '&':
         out += "&amp;";
         break;
@@ -33,7 +33,7 @@ static String htmlEscape(const char* s) {
         out += "&gt;";
         break;
       default:
-        out += *p;
+        out += c;
     }
   }
   return out;
@@ -48,15 +48,15 @@ static String buildPage() {
   page.replace("__CITY__", htmlEscape(cfg.city));
   page.replace("__LATITUDE__", htmlEscape(cfg.latitude));
   page.replace("__LONGITUDE__", htmlEscape(cfg.longitude));
-  page.replace("__UNITS_M__", strcmp(cfg.units, "I") == 0 ? "" : "selected");
-  page.replace("__UNITS_I__", strcmp(cfg.units, "I") == 0 ? "selected" : "");
+  page.replace("__UNITS_M__", cfg.units == "I" ? "" : "selected");
+  page.replace("__UNITS_I__", cfg.units == "I" ? "selected" : "");
 
   // Language options
   const char* langs[] = {"EN", "AR", "CZ", "EL", "FA", "FR", "GL", "HU",
                          "JA", "KR", "LA", "LT", "MK", "SK", "SL", "VI"};
   for (const char* lang : langs) {
     String token = String("__LANG_") + lang + "__";
-    page.replace(token, strcmp(cfg.language, lang) == 0 ? "selected" : "");
+    page.replace(token, cfg.language == lang ? "selected" : "");
   }
 
   page.replace("__TIMEZONE__", htmlEscape(cfg.timezone));
@@ -103,10 +103,9 @@ static void handleRoot() {
   httpServer.send(200, "text/html", buildPage());
 }
 
-// Reject and respond 400 if the named form field exceeds the target buffer.
-// String::toCharArray() does not null-terminate when src >= dest size.
-#define CHECK_FIELD_LEN(name, buf)                               \
-  if (httpServer.arg(name).length() >= sizeof(buf)) {            \
+// Reject and respond 400 if the named form field exceeds a reasonable max length.
+#define CHECK_FIELD_LEN(name, maxlen)                            \
+  if (httpServer.arg(name).length() > maxlen) {                  \
     httpServer.send(400, "text/plain", "Field too long: " name); \
     return;                                                      \
   }
@@ -114,38 +113,38 @@ static void handleRoot() {
 static void handleSave() {
   auto arg = [](const char* n) { return httpServer.arg(n); };
 
-  CHECK_FIELD_LEN("ssid", cfg.ssid)
-  CHECK_FIELD_LEN("apikey", cfg.apikey)
-  CHECK_FIELD_LEN("server", cfg.server)
-  CHECK_FIELD_LEN("city", cfg.city)
-  CHECK_FIELD_LEN("latitude", cfg.latitude)
-  CHECK_FIELD_LEN("longitude", cfg.longitude)
-  CHECK_FIELD_LEN("language", cfg.language)
-  CHECK_FIELD_LEN("units", cfg.units)
-  CHECK_FIELD_LEN("timezone", cfg.timezone)
-  CHECK_FIELD_LEN("ntpServer", cfg.ntpServer)
+  CHECK_FIELD_LEN("ssid", 63)
+  CHECK_FIELD_LEN("apikey", 63)
+  CHECK_FIELD_LEN("server", 63)
+  CHECK_FIELD_LEN("city", 63)
+  CHECK_FIELD_LEN("latitude", 15)
+  CHECK_FIELD_LEN("longitude", 15)
+  CHECK_FIELD_LEN("language", 7)
+  CHECK_FIELD_LEN("units", 3)
+  CHECK_FIELD_LEN("timezone", 79)
+  CHECK_FIELD_LEN("ntpServer", 63)
 
-  arg("ssid").toCharArray(cfg.ssid, sizeof(cfg.ssid));
+  cfg.ssid = arg("ssid").c_str();
 
   // Only overwrite password if user typed something
   String pw = arg("password");
   if (pw.length() > 0) {
-    if (pw.length() >= sizeof(cfg.password)) {
+    if (pw.length() > 63) {
       httpServer.send(400, "text/plain", "Field too long: password");
       return;
     }
-    pw.toCharArray(cfg.password, sizeof(cfg.password));
+    cfg.password = pw.c_str();
   }
 
-  arg("apikey").toCharArray(cfg.apikey, sizeof(cfg.apikey));
-  arg("server").toCharArray(cfg.server, sizeof(cfg.server));
-  arg("city").toCharArray(cfg.city, sizeof(cfg.city));
-  arg("latitude").toCharArray(cfg.latitude, sizeof(cfg.latitude));
-  arg("longitude").toCharArray(cfg.longitude, sizeof(cfg.longitude));
-  arg("language").toCharArray(cfg.language, sizeof(cfg.language));
-  arg("units").toCharArray(cfg.units, sizeof(cfg.units));
-  arg("timezone").toCharArray(cfg.timezone, sizeof(cfg.timezone));
-  arg("ntpServer").toCharArray(cfg.ntpServer, sizeof(cfg.ntpServer));
+  cfg.apikey = arg("apikey").c_str();
+  cfg.server = arg("server").c_str();
+  cfg.city = arg("city").c_str();
+  cfg.latitude = arg("latitude").c_str();
+  cfg.longitude = arg("longitude").c_str();
+  cfg.language = arg("language").c_str();
+  cfg.units = arg("units").c_str();
+  cfg.timezone = arg("timezone").c_str();
+  cfg.ntpServer = arg("ntpServer").c_str();
   cfg.gmtOffset_sec = arg("gmtOffset_sec").toInt();
   cfg.daylightOffset_sec = arg("daylightOffset_sec").toInt();
   cfg.sleepDuration = arg("sleepDuration").toInt();


### PR DESCRIPTION
## Summary

Bug fixes, security hardening, and code quality improvements — applied while `main.cpp` was still the single monolithic source file. The module split and naming refactor that follow are in a separate PR (#19) built on top of this one.

### Bug fixes
- Stop WiFi on fetch failure; fix pressure-trend loop off-by-one; remove dangling DNS variable and stale array declaration
- Remove leftover raw JSON stream dump from `DecodeWeather`
- Replace `sprintf` with `snprintf` in `UpdateLocalTime` (buffer safety)
- Fix simulator: include `defaults.h` for `kLayout*` / `kBattery*` constants (guarded out of simulator build in `main.cpp`)

### Security
- Add `CHECK_FIELD_LEN` input validation to all portal form fields — prevents buffer overflow into config fields from a crafted POST
- Add `ENABLE_CONFIG_DOWNLOAD` / `REDACT_PASSWORD_IN_CONFIG_DOWNLOAD` / `REDACT_APIKEY_IN_CONFIG_DOWNLOAD` compile-time options controlling the `GET /config.json` endpoint

### Structural / code quality
- Extract default config values to `include/defaults.h`
- Introduce `GraphConfig` struct + `calculateGraphYScale` helper to de-duplicate graph drawing calls
- Replace `String` struct members in `ForecastRecord` with fixed-size `char[]` arrays; use `const char*` for icon name params
- Named `constexpr` constants for display layout coordinates and hardware pins (replaces magic numbers)
- Replace `#define` constants with `constexpr`; switch to `Serial.printf`
- Replace repeated `strcmp(cfg.units, "M")` with a local `isMetric` bool
- Remove `bool == true/false` comparisons; replace deprecated `boolean` with `bool`
- Pass `String` parameters by `const reference`; remove redundant `JsonObject` in `DecodeWeather`

### AppConfig: char arrays -> std::string
Replace the eleven fixed-size `char[]` fields in `AppConfig` with `std::string`:
- Eliminates all `strlcpy` / `toCharArray` / `sizeof(field)` boilerplate in `config.cpp`, `setup_portal.cpp`, and `main.cpp`
- `strcmp(cfg.units, "M") == 0` -> `cfg.units == "M"` throughout
- `cfg.ssid[0] != '\0'` -> `!cfg.ssid.empty()`
- `htmlEscape` updated to take `const std::string&`
- `CHECK_FIELD_LEN` updated to take explicit numeric max-length args (same limits as before)
- `.c_str()` used only at the handful of C API boundaries (`WiFi.begin`, `configTime`, `setenv`, `http.begin`)

## Test plan

- [x] Firmware builds clean: `pio run`
- [x] Simulator builds clean: `cmake --build simulator/build`
- [x] clang-format passes: `clang-format --dry-run --Werror src/*.cpp include/*.h`
- [x] Biome passes: `bun run format:check`
- [x] Flash to device and confirm weather display renders correctly end-to-end
- [x] Open setup portal, verify all form fields populate and save correctly
- [x] Confirm OTA update page loads

Generated with [Claude Code](https://claude.com/claude-code)