### PR TITLE
ci(compile-check): add path filter to skip docs-only PRs

### DIFF
--- a/.github/workflows/compile-check.yml
+++ b/.github/workflows/compile-check.yml
@@ -2,6 +2,11 @@ name: Compile Check
 
 on:
   pull_request:
+    paths:
+      - 'src/**'
+      - 'include/**'
+      - 'platformio.ini'
+      - '.github/workflows/compile-check.yml'
   workflow_call:
 
 jobs:


### PR DESCRIPTION
## Summary

- Adds a `paths:` filter to the `pull_request` trigger in `compile-check.yml`
- The workflow now only runs when `src/**`, `include/**`, `platformio.ini`, or the workflow file itself changes
- Docs-only PRs (e.g. markdown, `doc/`, `LICENSE`) will no longer trigger an unnecessary firmware compile

## Test plan

- [ ] Merge a PR that only changes `.md` files — `compile-check` should be skipped
- [ ] Merge a PR that changes `src/` or `include/` — `compile-check` should trigger as normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)