### PR TITLE
ci(simulator): bump setup-emsdk from v14 to v16

### DIFF
--- a/.github/workflows/simulator-build.yml
+++ b/.github/workflows/simulator-build.yml
@@ -29,7 +29,7 @@ jobs:
         run: pio pkg install
 
       - name: Install Emscripten
-        uses: mymindstorm/setup-emsdk@v14
+        uses: mymindstorm/setup-emsdk@v16
 
       - name: Install Ninja
         run: sudo apt-get install -y ninja-build

--- a/.github/workflows/simulator-build.yml
+++ b/.github/workflows/simulator-build.yml
@@ -3,6 +3,7 @@ name: Simulator Build
 on:
   pull_request:
     paths:
+      - ".github/workflows/simulator-build.yml"
       - "simulator/**"
       - "src/main.cpp"
       - "include/**"


### PR DESCRIPTION
## Summary
- Bumps \`mymindstorm/setup-emsdk\` from v14 to v16 in the simulator build workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)