### PR TITLE
ci: enable Dependabot for GitHub Actions and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to enable Dependabot version checks
- Tracks `github-actions` ecosystem weekly (actions pinned across all five workflows)
- Tracks `npm` ecosystem weekly for Bun/Node dependencies (separate commit — revert `ee9e059` if not wanted)

## Test plan

- [ ] Merge and verify the ecosystems appear under **Insights > Dependency graph > Dependabot**
- [ ] Confirm a Dependabot PR is opened within the next scheduled weekly window

🤖 Generated with [Claude Code](https://claude.com/claude-code)