### PR TITLE
fix(pages): serve firmware from GitHub Pages to avoid CORS on release assets

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/pages.yml'
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -22,6 +24,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Download firmware from all releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p docs/firmware
+          gh release list --json tagName --jq '.[].tagName' | \
+            while IFS= read -r tag; do
+              gh release download "$tag" --pattern "firmware*.bin" --dir docs/firmware --clobber || true
+            done
 
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/bun.lock
+++ b/bun.lock
@@ -5,27 +5,27 @@
     "": {
       "name": "lilygo-epd47-owm-weather",
       "devDependencies": {
-        "@biomejs/biome": "2.4.15",
+        "@biomejs/biome": "2.4.16",
       },
     },
   },
   "packages": {
-    "@biomejs/biome": ["@biomejs/biome@2.4.15", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.15", "@biomejs/cli-darwin-x64": "2.4.15", "@biomejs/cli-linux-arm64": "2.4.15", "@biomejs/cli-linux-arm64-musl": "2.4.15", "@biomejs/cli-linux-x64": "2.4.15", "@biomejs/cli-linux-x64-musl": "2.4.15", "@biomejs/cli-win32-arm64": "2.4.15", "@biomejs/cli-win32-x64": "2.4.15" }, "bin": { "biome": "bin/biome" } }, "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.16", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.16", "@biomejs/cli-darwin-x64": "2.4.16", "@biomejs/cli-linux-arm64": "2.4.16", "@biomejs/cli-linux-arm64-musl": "2.4.16", "@biomejs/cli-linux-x64": "2.4.16", "@biomejs/cli-linux-x64-musl": "2.4.16", "@biomejs/cli-win32-arm64": "2.4.16", "@biomejs/cli-win32-x64": "2.4.16" }, "bin": { "biome": "bin/biome" } }, "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.15", "", { "os": "win32", "cpu": "x64" }, "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
   }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -217,7 +217,6 @@ footer a {
     <script>
 const REPO = "pfeerick/LilyGo-EPD-4-7-OWM-Weather-Display";
 const API_URL = `https://api.github.com/repos/${REPO}/releases`;
-const DOWNLOAD_BASE = `https://github.com/${REPO}/releases/download`;
 
 let activeTab = "releases";
 let selectedTag = null;
@@ -261,7 +260,7 @@ function updateButton() {
         : isLatest
           ? "firmware-latest.bin"
           : `firmware-${selectedTag}.bin`;
-    binaryUrl = `${DOWNLOAD_BASE}/${selectedTag}/${filename}`;
+    binaryUrl = `firmware/${filename}`;
   } else if (activeTab === "local" && localFileUrl) {
     binaryUrl = localFileUrl;
   }

--- a/index.js
+++ b/index.js
@@ -161,27 +161,22 @@ const server = Bun.serve({
         `<a href="/display" style="flex:1;text-align:center;padding:12px;color:#aaa;text-decoration:none">Display</a>` +
         `<a href="/flash" style="flex:1;text-align:center;padding:12px;color:#fff;text-decoration:none;font-weight:600">Flash</a>` +
         `</nav>`;
-      // Proxy GitHub release downloads through the local server to avoid CORS issues.
-      // This script is only injected in dev mode; the GitHub Pages version is unaffected.
-      const fetchProxy =
-        `<script>` +
-        `const _f=window.fetch;` +
-        `window.fetch=(u,...a)=>{` +
-        `if(typeof u==="string"&&u.startsWith("https://github.com/pfeerick/LilyGo-EPD-4-7-OWM-Weather-Display/releases/download/"))` +
-        `u="/release-proxy?url="+encodeURIComponent(u);` +
-        `return _f(u,...a);};` +
-        `</script>`;
-      html = html.replace("</head>", `${fetchProxy}\n</head>`);
       html = html.replace("<main>", `${devNav}\n    <main style="margin-top:44px">`);
       return new Response(html, { headers: { "Content-Type": "text/html; charset=utf-8" } });
     }
 
-    if (req.method === "GET" && pathname === "/release-proxy") {
-      const target = new URL(req.url).searchParams.get("url") ?? "";
-      const allowed = "https://github.com/pfeerick/LilyGo-EPD-4-7-OWM-Weather-Display/releases/download/";
-      if (!target.startsWith(allowed)) return new Response("Forbidden", { status: 403 });
-      const upstream = await fetch(target);
-      if (!upstream.ok) return new Response("Upstream error", { status: upstream.status });
+    // Proxy firmware binary requests to GitHub releases (avoids CORS issues in dev).
+    // On GitHub Pages the files are served directly from docs/firmware/ (same origin).
+    if (req.method === "GET" && pathname.startsWith("/firmware/")) {
+      const filename = pathname.slice("/firmware/".length);
+      if (!/^firmware[-\w.]+\.bin$/.test(filename)) return new Response("Forbidden", { status: 403 });
+      const match = filename.match(/^firmware(?:-factory)?-(.+)\.bin$/);
+      if (!match) return new Response("Not Found", { status: 404 });
+      const tag = match[1];
+      const upstream = await fetch(
+        `https://github.com/pfeerick/LilyGo-EPD-4-7-OWM-Weather-Display/releases/download/${tag}/${filename}`,
+      );
+      if (!upstream.ok) return new Response("Not Found", { status: upstream.status });
       const headers = { "Content-Type": "application/octet-stream" };
       const len = upstream.headers.get("Content-Length");
       if (len) headers["Content-Length"] = len;


### PR DESCRIPTION
## Problem

The "From releases" tab on the GitHub Pages flash page fails with "Failed to fetch" when attempting to install firmware.

Root cause: `objects.githubusercontent.com` (Azure Blob Storage — the CDN behind GitHub release asset downloads) does not send `Access-Control-Allow-Origin` CORS headers. Any cross-origin `fetch()` of a GitHub release asset is blocked by the browser, regardless of the requesting origin.

## Fix

Serve the firmware binaries from GitHub Pages itself (same origin = no CORS restriction):

- **`pages.yml`**: Added a step that downloads all release firmware binaries into `docs/firmware/` before the Pages artifact is uploaded. Also added a `release: [published]` trigger so the hosted binaries are refreshed whenever a new release is published.
- **`docs/index.html`**: Changed the binary URL from `https://github.com/.../releases/download/{tag}/{file}` to the relative path `firmware/{file}`, which resolves to the same GitHub Pages origin.
- **`index.js`** (dev server): Replaced the fetch-interceptor hack (which rewrote release download URLs to a `/release-proxy` endpoint) with a cleaner `/firmware/{filename}` route that proxies the download server-side. No fetch monkey-patching needed.

## Test plan

- [ ] Merge and confirm `pages.yml` runs, downloads firmware into `docs/firmware/`, and deploys successfully
- [ ] Open the hosted flash page — "From releases" tab should populate and Install should succeed without "Failed to fetch"
- [ ] `bun run dev` — `http://localhost:3000/flash` release tab should work via the `/firmware/` proxy route
- [ ] Local file tab still works for both Factory and Update Flash

Generated with [Claude Code](https://claude.com/claude-code)
