### PR TITLE
ci(pages): deploy pages from release workflow after release completes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,8 +6,7 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/pages.yml'
-  release:
-    types: [published]
+  workflow_call:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,3 +138,11 @@ jobs:
             firmware-factory-latest.bin \
             simulator-wasm-latest.js \
             simulator-wasm-latest.wasm
+
+  pages:
+    needs: [release]
+    uses: ./.github/workflows/pages.yml
+    permissions:
+      contents: read
+      pages: write
+      id-token: write


### PR DESCRIPTION
## Summary

- Replaces the `release: published` trigger on `pages.yml` with a `workflow_call` trigger, making it a reusable workflow callable from `release.yml`
- Adds a `pages` job to `release.yml` that runs after the `release` job, calling `pages.yml` directly
- Ensures firmware binaries are fully uploaded to the GitHub release before the Pages site is built and deployed — previously `pages.yml` could race ahead of `release.yml` and deploy without the new firmware

The `push: docs/**` and `workflow_dispatch` triggers on `pages.yml` are retained: the former covers docs-only changes (which don't trigger `release.yml`), the latter provides a manual escape hatch for forced redeployment.

## Test plan

- [ ] Push a non-docs change to `main` and confirm in the Actions tab that the `pages` job starts only after the `release` job completes within the same `release.yml` run
- [ ] Confirm no separate standalone `pages.yml` run fires for that same push
- [ ] Push a docs-only change to `main` and confirm `pages.yml` still fires independently via its `push: docs/**` trigger
- [ ] Trigger `workflow_dispatch` on `pages.yml` directly and confirm it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)