### PR TITLE
fix(pages): resolve firmware path to absolute URL before building manifest

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -13,8 +13,7 @@ No file download required. Alternatively, download `firmware-factory-*.bin` and 
 
 ### Update Flash
 
-Open the **[browser flasher](https://pfeerick.github.io/LilyGo-EPD-4-7-OWM-Weather-Display/)**,
-select a version, choose **Update Flash**, and click **Install**.
+Open the **[browser flasher](https://pfeerick.github.io/LilyGo-EPD-4-7-OWM-Weather-Display/)**, select a version, choose **Update Flash**, and click **Install**.
 This writes only the application binary and preserves your WiFi credentials and settings.
 
 Alternatively, use the on-device web portal (served over WiFi) to upload `firmware-*.bin`,

--- a/docs/index.html
+++ b/docs/index.html
@@ -260,7 +260,7 @@ function updateButton() {
         : isLatest
           ? "firmware-latest.bin"
           : `firmware-${selectedTag}.bin`;
-    binaryUrl = `firmware/${filename}`;
+    binaryUrl = new URL(`firmware/${filename}`, location.href).href;
   } else if (activeTab === "local" && localFileUrl) {
     binaryUrl = localFileUrl;
   }


### PR DESCRIPTION
## Summary

When the user selects a release and clicks flash, the manifest is created as a `blob:` URL and passed to esp-web-tools. esp-web-tools then resolves the `path` entries in the manifest relative to the manifest URL — but resolving a relative path like `firmware/firmware-latest.bin` against a `blob:` origin throws **"Failed to construct 'URL': Invalid URL"**.

Fix: wrap the relative firmware path with `new URL(..., location.href).href` so the manifest always receives an absolute `https://` URL regardless of where the manifest blob lives.

## Test plan

- [ ] Open the flasher page, select a release, choose **Update Flash** and confirm the install button appears without a console error
- [ ] Repeat with **Factory Flash**
- [ ] Test with the local file tab to confirm that path (already a blob URL) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)