### PR TITLE
fix(display): correct mirrored/inverted moon phase icon

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -216,20 +216,18 @@ void DrawMoon(int x, int y, int diameter, int dd, int mm, int yy, bool southernH
   int b = jd;
   jd -= b;
   double Phase = jd;
-  b = (int)(Phase * 8 + 0.5) & 7;
   if (southernHemisphere) Phase = 1 - Phase;
-  int octant = (int)(Phase * 8 + 0.5) & 7;
   FillCircle(x + diameter - 1, y + diameter, diameter / 2 + 1, kDarkGrey);
   const int number_of_lines = 90;
   for (double Ypos = 0; Ypos <= number_of_lines / 2; Ypos++) {
     double Xpos = sqrt(number_of_lines / 2 * number_of_lines / 2 - Ypos * Ypos);
     double Rpos = 2 * Xpos;
     double Xpos1, Xpos2;
-    if (octant < 5) {
-      Xpos1 = -Xpos;
+    if (Phase < 0.5) {
+      Xpos1 = Xpos;
       Xpos2 = Rpos - 2 * Phase * Rpos - Xpos;
     } else {
-      Xpos1 = Xpos;
+      Xpos1 = -Xpos;
       Xpos2 = Xpos - 2 * Phase * Rpos + Rpos;
     }
     double pW1x = (Xpos1 + number_of_lines) / number_of_lines * diameter + x;


### PR DESCRIPTION
## Summary
- `DrawMoon()` (the hand-drawn moon-phase graphic in the astronomy section) was rendering an illumination curve that is the **inverse and left/right mirror** of reality: New Moon rendered as a fully-lit disc, Full Moon as a fully-dark disc, and the quarter/crescent/gibbous shapes were lit on the opposite side from what `MoonPhase()`'s text label said (e.g. today the text reads "Third Quarter" but the icon showed the wrong side lit at the wrong percentage).
- Root cause: the function computes the correct terminator position (`Xpos2`) for each half of the lunar cycle, but pairs it with the wrong fixed circle edge (`Xpos1`) — `Xpos1 = -Xpos`/`Xpos1 = Xpos` were swapped between the two branches. Swapping them back makes the illuminated fraction and orientation match the phase value (and therefore the text label) for both hemispheres.
- Also switched the branch condition from the discrete `octant < 5` threshold to the continuous `Phase < 0.5`, removing the now-unused `b`/`octant` calculations and a small clipping glitch that occurred right at the full/new-moon boundary (octant boundaries sit at `Phase ≈ 0.0625/0.5625/0.9375`, not `0.5`).
- The existing `if (southernHemisphere) Phase = 1 - Phase;` mirroring needed no change — it correctly mirrors whichever base rendering it's given, and now mirrors a *correct* base rendering.

Verified against the WASM simulator for AU (southern hemisphere) on 2026-06-07 ("Third Quarter"):

| | Before | After |
|---|---|---|
| Illumination | ~47% | ~53% |
| Lit side | left | right (correct for southern hemisphere waning gibbous → third quarter) |

## Test plan
- [x] `clang-format -i src/display.cpp`
- [x] Rebuilt the WASM simulator (`emcmake`/`emmake` + Ninja) and rendered before/after screenshots with `bun run screenshot` — confirmed the icon now matches the "Third Quarter" label and the correct hemisphere-mirrored orientation
- [x] `pio run` builds the firmware successfully