### PR TITLE
fix(display): align moon phase labeling with standard almanac convention

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -229,16 +229,15 @@ void DrawMoon(int x, int y, int diameter, float phase, bool southernHemisphere) 
 }
 
 String MoonPhase(float phase) {
-  int b = (int)(phase * 8 + 0.5) & 7;
-  if (b == 0) return TXT_MOON_NEW;
-  if (b == 1) return TXT_MOON_WAXING_CRESCENT;
-  if (b == 2) return TXT_MOON_FIRST_QUARTER;
-  if (b == 3) return TXT_MOON_WAXING_GIBBOUS;
-  if (b == 4) return TXT_MOON_FULL;
-  if (b == 5) return TXT_MOON_WANING_GIBBOUS;
-  if (b == 6) return TXT_MOON_THIRD_QUARTER;
-  if (b == 7) return TXT_MOON_WANING_CRESCENT;
-  return "";
+  constexpr float kPhaseWindow = 1.0f / 29.53f;  // ~1 day either side of an exact quarter phase
+  if (phase >= 1.0f - kPhaseWindow || phase < kPhaseWindow) return TXT_MOON_NEW;
+  if (phase < 0.25f - kPhaseWindow) return TXT_MOON_WAXING_CRESCENT;
+  if (phase <= 0.25f + kPhaseWindow) return TXT_MOON_FIRST_QUARTER;
+  if (phase < 0.5f - kPhaseWindow) return TXT_MOON_WAXING_GIBBOUS;
+  if (phase <= 0.5f + kPhaseWindow) return TXT_MOON_FULL;
+  if (phase < 0.75f - kPhaseWindow) return TXT_MOON_WANING_GIBBOUS;
+  if (phase <= 0.75f + kPhaseWindow) return TXT_MOON_THIRD_QUARTER;
+  return TXT_MOON_WANING_CRESCENT;
 }
 
 void DisplayForecastSection(int x, int y) {


### PR DESCRIPTION
## Summary
- `MoonPhase()` previously divided the lunar cycle into 8 equal 0.125-wide buckets, so "Third Quarter" covered the range `[0.6875, 0.8125)` — about ±1.5 days around the actual quarter-moon date.
- Reference sites like timeanddate.com only use the four "instant" phase names (New, First Quarter, Full, Third Quarter) within ~1 day of the exact phase value, with Waxing/Waning Crescent/Gibbous covering the much wider in-between ranges.
- This PR narrows the four "instant" phase windows to ~1/29.53 (~1 day) and widens the crescent/gibbous ranges accordingly, so e.g. `moon_phase: 0.81` now correctly reads "Waning Crescent" instead of "Third Quarter".
- `DrawMoon()` (the rendered moon graphic) is unaffected — it already uses the continuous phase value directly.

## Test plan
- [x] `clang-format -i src/display.cpp`
- [x] Rebuilt simulator WASM (Emscripten + Ninja) and confirmed via `bun run screenshot` that the astronomy section now shows "Waning Crescent" for the current `moon_phase: 0.81` data
- [x] `pio run` builds the firmware successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)